### PR TITLE
Cookie umstellen auf secure und Strict

### DIFF
--- a/assets/consent_manager_frontend.js
+++ b/assets/consent_manager_frontend.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // es gibt keinen datenschutzcookie, banner zeigen
     if (typeof Cookies.get('consent_manager') === 'undefined') {
         show = 1;
-        Cookies.set('test', 'test', {path: '/', sameSite: 'Lax', secure: false});
+        Cookies.set('test', 'test', {path: '/', secure: true, sameSite: 'Strict'});
         // cookie konnte nicht gesetzt werden, kein cookie banner anzeigen
         if (typeof Cookies.get('test') === 'undefined') {
             show = 0;
@@ -110,7 +110,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
         cookieData.consents = consents;
-        Cookies.set('consent_manager', JSON.stringify(cookieData), {expires: expires, path: '/', sameSite: 'Lax', secure: false});
+        Cookies.set('consent_manager', JSON.stringify(cookieData), {expires: expires, path: '/', secure: true, sameSite: 'Strict'});
 
         var http = new XMLHttpRequest(),
             url = '/index.php?rex-api-call=consent_manager',


### PR DESCRIPTION
Wie bei den Issues schon diskutiert, werden künftig Cookies in Firefox künftig abgelehnt, welche 'sameSite' nicht definiert haben. 
Ausserdem ist 'secure' (vgl. https, ssh) als sichere übertragen natürlich prinzipiell auch besser (Stichwort: man in the middle attacks) .
Die vorgeschlagene Änderung funktioniert auf Firefox Mac einwandfrei.

Das ist mein erster PullRequest auf GitHub. Ich hoffe ich hab das so richtig gemacht. ;-)