### PR TITLE
Update CSSJS-Optimierung

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ Standardmäßig wird auf jeder Seite das benötigte JavaScript und die CSS-Datei
 
 Der Platzhalter `REX_CONSENT_MANAGER[]` im Template wird durch folgenden Code ersetzt.
 ```html
-<link rel="stylesheet" href="/assets/addons/consent_manager/consent_manager_frontend.css?v=1610741049">
-<script>var consent_manager_initially_hidden = false;</script>
-<script src="/index.php?consent_manager_outputjs=1&amp;v=1610705007"></script>
+    <link rel="stylesheet" href="/assets/addons/consent_manager/consent_manager_frontend.css?v=1610997727">
+    <script>consent_manager_parameters = { initially_hidden: false, domain: "domain.de", consentid: "6005e443914e75.55868698", cacheLogId: "46", version: "3", fe_controller: "/index.php" };</script>
+    <script src="/index.php?consent_manager_outputjs=1&amp;v=1610978112" id="consent_manager_script"></script>
 ```
 Sind im eigenen Frontend-Theme Styles für die Consent-Box vorhanden kann hier die Ausgabe der CSS-Datei `consent_manager_frontend.css` durch aktivieren der Einstellung **Eigenes CSS verwenden** unterdrückt werden. Es werden dann nur die JavaScript-Zeilen ausgegeben.
 

--- a/assets/consent_manager_frontend.js
+++ b/assets/consent_manager_frontend.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', function () {
     document.querySelectorAll('body')[0].appendChild(consent_managerBox);
 
     // aktuelle major addon version auslesen
-    addonVersion = parseInt(document.getElementById('consent_manager-background').getAttribute('data-version'));
+    addonVersion = parseInt(consent_manager_parameters.version);
     // cookie wurde mit einer aelteren major version gesetzt, alle consents loeschen und box zeigen
     if (addonVersion !== cookieVersion) {
         show = 1;
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', function () {
         addScript(consent_managerBox.querySelector('[data-uid="' + uid + '"]'));
     });
 
-    if (consent_manager_initially_hidden) {
+    if (consent_manager_parameters.initially_hidden) {
         show = 0;
     }
 
@@ -91,8 +91,8 @@ document.addEventListener('DOMContentLoaded', function () {
         cookieData = {
             consents: [],
             version: addonVersion,
-            consentid: document.getElementById('consent_manager-background').getAttribute('data-consentid'),
-            cachelogid: document.getElementById('consent_manager-background').getAttribute('data-cachelogid')
+            consentid: consent_manager_parameters.consentid,
+            cachelogid: consent_manager_parameters.cacheLogId
         };
         // checkboxen
         consent_managerBox.querySelectorAll('[data-cookie-uids]').forEach(function (el) {
@@ -113,8 +113,8 @@ document.addEventListener('DOMContentLoaded', function () {
         Cookies.set('consent_manager', JSON.stringify(cookieData), {expires: expires, path: '/', sameSite: 'Lax', secure: false});
 
         var http = new XMLHttpRequest(),
-            url = '/index.php?rex-api-call=consent_manager',
-            params = 'consentid=' + document.getElementById('consent_manager-background').getAttribute('data-consentid');
+            url = consent_manager_parameters.fe_controller + '?rex-api-call=consent_manager',
+            params = 'consentid=' + consent_manager_parameters.consentid;
         http.open('POST', url, true);
         http.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
         http.send(params);
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function deleteCookies() {
-        var domain = document.getElementById('consent_manager-background').getAttribute('data-domain-name');
+        var domain = consent_manager_parameters.domain;
         for (var key in Cookies.get()) {
             Cookies.remove(encodeURIComponent(key));
             Cookies.remove(encodeURIComponent(key), {'domain': domain});

--- a/boot.php
+++ b/boot.php
@@ -64,9 +64,9 @@ rex_extension::register('OUTPUT_FILTER', function (rex_extension_point $ep) {
     }
 });
 
-rex_extension::register('FE_OUTPUT', static function (rex_extension_point $ep) {
+rex_extension::register('PACKAGES_INCLUDED', static function (rex_extension_point $ep) {
     if (rex_get('consent_manager_outputjs', 'bool', false) === true) {
-        $consent_manager = new consent_manager_frontend($_SESSION['consent_manager']['forceCache']);
+        $consent_manager = new consent_manager_frontend(0);
         $consent_manager->setDomain($_SERVER['HTTP_HOST']);
         $consent_manager->outputJavascript();
     }

--- a/fragments/consent_manager_box.php
+++ b/fragments/consent_manager_box.php
@@ -1,5 +1,5 @@
 <?php
-$consent_manager = new consent_manager_frontend($_SESSION['consent_manager']['forceCache']);
+$consent_manager = new consent_manager_frontend(0);
 $consent_manager->setDomain($_SERVER['HTTP_HOST']);
 ?>
 <?php if ($consent_manager->cookiegroups): ?>

--- a/fragments/consent_manager_box_cssjs.php
+++ b/fragments/consent_manager_box_cssjs.php
@@ -5,16 +5,15 @@ $forceCache = $this->getVar('forceCache');
 
 $_SESSION['consent_manager']['article'] = rex_article::getCurrentId();
 $_SESSION['consent_manager']['debug'] = $debug;
-$_SESSION['consent_manager']['forceCache'] = $forceCache;
 $_SESSION['consent_manager']['outputcssjs'] = '';
 
 $initially_hidden = 'false';
-$consent_manager = new consent_manager_frontend(0);
+$consent_manager = new consent_manager_frontend($forceCache);
 $consent_manager->setDomain($_SERVER['HTTP_HOST']);
 if (rex_article::getCurrentId() == $consent_manager->links['privacy_policy'] || rex_article::getCurrentId() == $consent_manager->links['legal_notice']) {
-	$initially_hidden = 'true';
+    $initially_hidden = 'true';
 }
-		
+
 $output = '';
 
 if ('|1|' <> $addon->getConfig('outputowncss', false)) {
@@ -22,11 +21,11 @@ if ('|1|' <> $addon->getConfig('outputowncss', false)) {
     $output .= '    <link rel="stylesheet" href="' . rex_url::base($_cssfilename) . '?v=' . filemtime(rex_path::base($_cssfilename)) . '">' . PHP_EOL;
 }
 
-$output .= '    <script>var consent_manager_initially_hidden = ' . $initially_hidden . ';</script>' . PHP_EOL;
+$output .= '    <script>consent_manager_parameters = { initially_hidden: ' . $initially_hidden . ', domain: "' . $_SERVER['HTTP_HOST'] . '", consentid: "' . uniqid('', true) . '", cacheLogId: "' . $consent_manager->cacheLogId . '", version: "' . $consent_manager->version . '", fe_controller: "' . rex_url::frontendController(). '" };</script>' . PHP_EOL;
 $_params = [];
 $_params['consent_manager_outputjs'] = true;
 $_params['v'] = filemtime(rex_path::base('assets/addons/consent_manager/consent_manager_frontend.js'));
-$output .= '    <script src="' . rex_url::frontendController($_params) . '"></script>';
+$output .= '    <script src="' . rex_url::frontendController($_params) . '" id="consent_manager_script"></script>';
 
 $_SESSION['consent_manager']['outputcssjs'] = $output;
 ?>

--- a/lib/consent_manager_frontend.php
+++ b/lib/consent_manager_frontend.php
@@ -12,6 +12,7 @@ class consent_manager_frontend
     public $boxClass = '';
     public $cache = [];
     public $version = '';
+	public $cacheLogId = '';
 
     public function __construct($forceWrite = 0)
     {
@@ -84,7 +85,7 @@ class consent_manager_frontend
         //header('Cache-Control: public');
         //header('Expires: ' . date('D, j M Y', strtotime('+1 week')) . ' 00:00:00 GMT');
         ob_start();
-        echo self::getFragment($_SESSION['consent_manager']['debug'], $_SESSION['consent_manager']['forceCache'], 'consent_manager_box.php');
+        echo self::getFragment($_SESSION['consent_manager']['debug'], 0, 'consent_manager_box.php');
         $boxtemplate = ob_get_contents();
         ob_end_clean(); 
         $boxtemplate = str_replace("'", "\'", $boxtemplate);

--- a/package.yml
+++ b/package.yml
@@ -1,10 +1,11 @@
 package: consent_manager
-version: '2.0.1'
+version: '3.0.0beta1'
 author: 'Friends Of REDAXO'
 supportpage: https://redaxo.org/support/community/#slack
 
 requires:
     redaxo: '^5.8'
+    php: '>=7.1'
 
 page:
     title: 'translate:consent_manager_title'


### PR DESCRIPTION
- Mehr Parameter für JavaScript setzen, diese Werte statt data-Attribute aus Template verwenden
  Durch das Caching sind die Werte im Template evtl. nicht aktuell
- JavaScript Cookies speichern funktionierte nicht bei Installation im Unterverzeichnis
- forceCache wurde mehrmals ausgeführt
- EP FE_OUTPUT für die Ausgabe durch PACKAGES_INCLUDED ersetzt
- min. PHP-Version in package.yml gesetzt