### PR TITLE
Frontend JS nicht blockend laden

### DIFF
--- a/assets/consent_manager_frontend.js
+++ b/assets/consent_manager_frontend.js
@@ -1,5 +1,5 @@
 /* globals Cookies, consent_managerIEVersion */
-document.addEventListener('DOMContentLoaded', function () {
+(function () {
     'use strict';
     var expires = new Date(),
         show = 0,
@@ -188,4 +188,4 @@ document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('consent_manager-background').classList.remove('consent_manager-hidden');
     }
 
-});
+})();

--- a/fragments/consent_manager_box_cssjs.php
+++ b/fragments/consent_manager_box_cssjs.php
@@ -29,7 +29,7 @@ $_params = [];
 $_params['consent_manager_outputjs'] = true;
 $_params['clang'] = rex_clang::getCurrentId();
 $_params['v'] = filemtime($addon->getAssetsPath('consent_manager_frontend.js')) . rex_clang::getCurrentId();
-$output .= '    <script src="' . rex_url::frontendController($_params) . '" id="consent_manager_script" async></script>';
+$output .= '    <script src="' . rex_url::frontendController($_params) . '" id="consent_manager_script" defer></script>';
 
 $_SESSION['consent_manager']['cachelogid'] = $consent_manager->cacheLogId;
 $_SESSION['consent_manager']['outputcssjs'] = $output;

--- a/fragments/consent_manager_box_cssjs.php
+++ b/fragments/consent_manager_box_cssjs.php
@@ -29,7 +29,7 @@ $_params = [];
 $_params['consent_manager_outputjs'] = true;
 $_params['clang'] = rex_clang::getCurrentId();
 $_params['v'] = filemtime($addon->getAssetsPath('consent_manager_frontend.js')) . rex_clang::getCurrentId();
-$output .= '    <script src="' . rex_url::frontendController($_params) . '" id="consent_manager_script"></script>';
+$output .= '    <script src="' . rex_url::frontendController($_params) . '" id="consent_manager_script" async></script>';
 
 $_SESSION['consent_manager']['cachelogid'] = $consent_manager->cacheLogId;
 $_SESSION['consent_manager']['outputcssjs'] = $output;


### PR DESCRIPTION
Die Frontend JS Datei wird mit dem Attribut "defer" geladen, siehe https://github.com/FriendsOfREDAXO/consent_manager/issues/144