### PR TITLE
fix #165

### DIFF
--- a/lib/consent_manager_clang.php
+++ b/lib/consent_manager_clang.php
@@ -136,7 +136,7 @@ class consent_manager_clang
         }
         elseif (rex::getTable('consent_manager_cookie') == $form->getTableName())
         {
-            $fields2Update = ['uid'];
+            $fields2Update = ['uid', 'script'];
             $db = rex_sql::factory();
             $db->setTable($form->getTableName());
             $db->setWhere('pid = :pid', ['pid' => $form->getSql()->getValue('pid')]);

--- a/update.php
+++ b/update.php
@@ -2,3 +2,21 @@
 $addon = rex_addon::get('consent_manager');
 $addon->includeFile(__DIR__.'/install.php');
 $this->setConfig('forceCache', true);
+
+// Copy scripts to every language
+if(count(rex_clang::getAllIds()) > 1) {
+	$sql = \rex_sql::factory();
+	$sql->setQuery("SELECT `start_lang`.uid, `start_lang`.script FROM `". rex::getTablePrefix() ."consent_manager_cookie` AS `start_lang` "
+		. "LEFT JOIN `". rex::getTablePrefix() ."consent_manager_cookie` AS `other_lang` ON `start_lang`.uid = `other_lang`.uid "
+		. "WHERE `start_lang`.clang_id = ". rex_clang::getStartId() ." AND `start_lang`.script <> '' AND `other_lang`.script = '' "
+		. "GROUP BY uid, script");
+	for($i = 0; $i < $sql->getRows(); $i++) {
+		$db = rex_sql::factory();
+		$db->setTable(rex::getTable('consent_manager_cookie'));
+		$db->setWhere('uid = :uid AND clang_id <> :clang_id AND script = ""', ['uid' => $sql->getValue("uid"), 'clang_id' => rex_clang::getStartId()]);
+		$db->setValue('script', $sql->getValue("script"));
+		$db->update();
+
+		$sql->next();
+	}
+}


### PR DESCRIPTION
Behebt https://github.com/FriendsOfREDAXO/consent_manager/issues/165

- Beim Speichern der Cookies wird das Script in allen Sprachen gespeichert.
- update.php kopiert die Skripte in alle Sprachen in denen noch kein Skript vorhanden war.