### PR TITLE
write cache after update

### DIFF
--- a/update.php
+++ b/update.php
@@ -19,4 +19,7 @@ if(count(rex_clang::getAllIds()) > 1) {
 
 		$sql->next();
 	}
+	
+	// Write cache
+	consent_manager_cache::forceWrite();
 }


### PR DESCRIPTION
In https://github.com/FriendsOfREDAXO/consent_manager/pull/168 habe ich glaub vergessen, dass der Cache nach in der update.php neu geschrieben werden muss. Ingo, liege ich da richtig?