### PR TITLE
README.md Gesetzte Cookies / Einwilligungshistorie

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ Sind im eigenen Frontend-Theme Styles für die Consent-Box vorhanden kann hier d
 Soll JavaScript für die Consent-Box nur ausgegeben werden wenn dies auch notwendig ist, kann das durch aktivieren der Einstellung **CSS + JavaScript im Frontend nur bei Bedarf ausgeben** erreicht werden.
 JavaScript wird dann nur ausgegeben wenn noch kein Cookie gesetzt wurde, wenn Cookies entfallen oder neu hinzugefügt wurden, oder auf der Seite ein Link mit der Klasse `consent_manager-show-box` oder `consent_manager-show-box-reload` existiert.
 
+### Gesetzte Cookies / Einwilligungshistorie
+
+Über den Aufruf von REX_COOKIEDB[] können alle derzeit gesetzten Cookies swoie die Einwilligungshistorie z.B. in der Datenschutzerklärung ausgegeben werden. 
+
 ## Tipps & Tricks
 
 Hast du eigene Tipps & Tricks? [Füge Sie auf Github direkt in die Readme hinzu](https://github.com/FriendsOfREDAXO/consent_manager/blob/master/README.md) oder lege ein [Issue](https://github.com/FriendsOfREDAXO/consent_manager/issues) an.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Sind im eigenen Frontend-Theme Styles für die Consent-Box vorhanden kann hier d
 Soll JavaScript für die Consent-Box nur ausgegeben werden wenn dies auch notwendig ist, kann das durch aktivieren der Einstellung **CSS + JavaScript im Frontend nur bei Bedarf ausgeben** erreicht werden.
 JavaScript wird dann nur ausgegeben wenn noch kein Cookie gesetzt wurde, wenn Cookies entfallen oder neu hinzugefügt wurden, oder auf der Seite ein Link mit der Klasse `consent_manager-show-box` oder `consent_manager-show-box-reload` existiert.
 
-### Gesetzte Cookies / Einwilligungshistorie
+## Gesetzte Cookies / Einwilligungshistorie
 
 Über den Aufruf von REX_COOKIEDB[] können alle derzeit gesetzten Cookies swoie die Einwilligungshistorie z.B. in der Datenschutzerklärung ausgegeben werden. 
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ JavaScript wird dann nur ausgegeben wenn noch kein Cookie gesetzt wurde, wenn Co
 
 ## Gesetzte Cookies / Einwilligungshistorie
 
-Über den Aufruf von REX_COOKIEDB[] können alle derzeit gesetzten Cookies swoie die Einwilligungshistorie z.B. in der Datenschutzerklärung ausgegeben werden. 
+Mit Hilfe des Platzhalters `REX_COOKIEDB[]` können alle derzeit gesetzten Cookies sowie die Einwilligungshistorie z.B. in der Datenschutzerklärung ausgegeben werden. 
 
 ## Tipps & Tricks
 


### PR DESCRIPTION
Ergänzung um den Absatz "Gesetzte Cookies / Einwilligungshistorie" zur Erklärung von REX_COOKIEDB[]