### PR TITLE
Consent synchron speichern

### DIFF
--- a/assets/consent_manager_frontend.js
+++ b/assets/consent_manager_frontend.js
@@ -126,7 +126,7 @@
         var http = new XMLHttpRequest(),
             url = consent_manager_parameters.fe_controller + '?rex-api-call=consent_manager',
             params = 'domain=' + consent_manager_parameters.domain + '&consentid=' + consent_manager_parameters.consentid;
-        http.open('POST', url, true);
+        http.open('POST', url, false);
         http.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
         http.send(params);
 


### PR DESCRIPTION
Wenn die Seite neu geladen wird, während der Request läuft, wird der Request abgebrochen und der Consent nicht ins Consent Log geschrieben.
https://usefulangle.com/post/62/javascript-send-data-to-server-on-page-exit-reload-redirect