### PR TITLE
rex_login::startSession() verwenden

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -59,7 +59,7 @@ if ($this->getConfig('forceCache')) {
 }
 if (rex::isFrontend()) {
     if (!isset($_SESSION)) {
-        session_start();
+        rex_login::startSession();
         $_SESSION['consent_manager']['article'] = rex_article::getCurrentId();
         $_SESSION['consent_manager']['outputcss'] = '';
         $_SESSION['consent_manager']['outputjs'] = '';

--- a/lib/consent_manager_frontend.php
+++ b/lib/consent_manager_frontend.php
@@ -82,7 +82,7 @@ class consent_manager_frontend
     {
         rex_response::cleanOutputBuffers();
         if (!isset($_SESSION)) {
-            session_start();
+            rex_login::startSession();
         }
         header('Content-Type: application/javascript');
         header('Cache-Control: max-age=604800, public');


### PR DESCRIPTION
sonst greifen die Einstellungen der config.yml zu den Cookies nicht.