### PR TITLE
check for null before ->getName()

### DIFF
--- a/fragments/consent_manager_box.php
+++ b/fragments/consent_manager_box.php
@@ -73,7 +73,7 @@ $consent_manager->setDomain($_SERVER['HTTP_HOST']);
                             <?php
                             $clang = rex_request('clang', 'integer', 1);
                             foreach ($consent_manager->links as $v) {
-                                echo '<a href="'.rex_getUrl($v, $clang).'">'. (!is_null(rex_article::get($v, $clang)) ? rex_article::get($v, $clang)->getName() : '').'</a>';
+                                echo '<a href="' . rex_getUrl($v, $clang) . '">' . (!is_null(rex_article::get($v, $clang)) ? rex_article::get($v, $clang)->getName() : '') . '</a>';
                             }
                             ?>
                         </div>

--- a/fragments/consent_manager_box.php
+++ b/fragments/consent_manager_box.php
@@ -73,7 +73,7 @@ $consent_manager->setDomain($_SERVER['HTTP_HOST']);
                             <?php
                             $clang = rex_request('clang', 'integer', 1);
                             foreach ($consent_manager->links as $v) {
-                                echo '<a href="' . rex_getUrl($v, $clang) . '">' . rex_article::get($v, $clang)->getName() . '</a>';
+                                echo '<a href="'.rex_getUrl($v, $clang).'">'. (!is_null(rex_article::get($v, $clang)) ? rex_article::get($v, $clang)->getName() : '').'</a>';
                             }
                             ?>
                         </div>


### PR DESCRIPTION
Gerade in einer Schulung auf die Schnauze gefallen, als wir eine neue Datenschutzrichtlinie erstellt haben und den alten Artikel gelöscht haben, dessen ID aber im consent manager hinterlegt ist... dann gibt es einen Ooops!
Weil im Code nicht auf "null" geprüft wird.