### PR TITLE
Consent-Parameter nicht inline ausgeben

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,7 @@ Standardmäßig wird auf jeder Seite das benötigte JavaScript und die CSS-Datei
 Der Platzhalter `REX_CONSENT_MANAGER[]` im Template wird durch folgenden Code ersetzt.
 
 ```html
-<link rel="stylesheet" href="/assets/addons/consent_manager/consent_manager_frontend.css?v=1610997727">
-<script>var consent_manager_parameters = {initially_hidden: false, domain: "domain.de", consentid: "6005e443914e75.55868698", cacheLogId: "46", version: "3", fe_controller: "/index.php", hidebodyscrollbar: true};</script>
+<style>.consent_manager-background{position:fixed ...;}</style>
 <script src="/index.php?consent_manager_outputjs=1&amp;clang=1&amp;v=1610978112" id="consent_manager_script"></script>
 ```
 
@@ -275,7 +274,7 @@ JavaScript wird dann nur ausgegeben wenn noch kein Cookie gesetzt wurde, wenn Co
 
 ## Gesetzte Cookies / Einwilligungshistorie
 
-Mit Hilfe des Platzhalters `REX_COOKIEDB[]` können alle derzeit gesetzten Cookies sowie die Einwilligungshistorie z.B. in der Datenschutzerklärung ausgegeben werden. 
+Mit Hilfe des Platzhalters `REX_COOKIEDB[]` können alle derzeit gesetzten Cookies sowie die Einwilligungshistorie z.B. in der Datenschutzerklärung ausgegeben werden.
 
 ## Tipps & Tricks
 

--- a/fragments/consent_manager_box_cssjs.php
+++ b/fragments/consent_manager_box_cssjs.php
@@ -28,9 +28,13 @@ if (!$addon->getConfig('outputowncss', false)) {
     $outputcss .= '    <style>' . trim(file_get_contents($addon->getAssetsPath($_cssfilename))) . '</style>' . PHP_EOL;
 }
 
-$hidesb = ('|1|' == $addon->getConfig('hidebodyscrollbar', false)) ? 'true' : 'false';
+$hidescrollbar = ('|1|' == $addon->getConfig('hidebodyscrollbar', false)) ? 'true' : 'false';
 
-$outputjs .= '    <script>var consent_manager_parameters = {initially_hidden: ' . $initially_hidden . ', domain: "' . $_SERVER['HTTP_HOST'] . '", consentid: "' . uniqid('', true) . '", cachelogid: "' . $consent_manager->cacheLogId . '", version: "' . $consent_manager->version . '", fe_controller: "' . rex_url::frontendController(). '", hidebodyscrollbar: '.$hidesb.'};</script>' . PHP_EOL;
+$_SESSION['consent_manager']['initially_hidden'] = $initially_hidden;
+$_SESSION['consent_manager']['cachelogid'] = $consent_manager->cacheLogId;
+$_SESSION['consent_manager']['version'] = $consent_manager->version;
+$_SESSION['consent_manager']['hidescrollbar'] = $hidescrollbar;
+
 $_params = [];
 $_params['consent_manager_outputjs'] = true;
 $_params['clang'] = rex_clang::getCurrentId();

--- a/lib/consent_manager_frontend.php
+++ b/lib/consent_manager_frontend.php
@@ -105,6 +105,8 @@ class consent_manager_frontend
             $boxtemplate = str_replace("\r", '', $boxtemplate);
             $boxtemplate = str_replace("\n", ' ', $boxtemplate);
         }
+        echo '/* --- Parameters --- */' . PHP_EOL;
+        echo 'var consent_manager_parameters = {initially_hidden: ' . $_SESSION['consent_manager']['initially_hidden'] . ', domain: "' . $_SERVER['HTTP_HOST'] . '", consentid: "' . uniqid('', true) . '", cachelogid: "' . $_SESSION['consent_manager']['cachelogid'] . '", version: "' . $_SESSION['consent_manager']['version'] . '", fe_controller: "' . rex_url::frontendController(). '", hidebodyscrollbar: ' . $_SESSION['consent_manager']['hidescrollbar'] . '};' . PHP_EOL . PHP_EOL;
         echo '/* --- Consent-Manager Box Template ' . $_SESSION['consent_manager']['clang'] . ' --- */' . PHP_EOL;
         echo 'var consent_manager_box_template = \'';
         echo $boxtemplate . '\';' . PHP_EOL . PHP_EOL;


### PR DESCRIPTION
Die Parameter für den Consent-Manager werden nicht mehr inline ausgegeben sondern nur noch ein Script-Aufruf bzw. Script-Tag wird eingefügt. Die Parameter stehen am Anfang des Scripts