### PR TITLE
Fehlendes "script-" ergänzt

### DIFF
--- a/assets/consent_manager_frontend.js
+++ b/assets/consent_manager_frontend.js
@@ -112,11 +112,11 @@
             if (el.checked || toSave === 'all') {
                 cookieUids.forEach(function (uid) {
                     consents.push(uid);
-                    addScript(consent_managerBox.querySelector('[data-uid="' + uid + '"]'));
+                    addScript(consent_managerBox.querySelector('[data-uid="script-' + uid + '"]'));
                 });
             } else {
                 cookieUids.forEach(function (uid) {
-                    removeScript(consent_managerBox.querySelector('[data-uid="' + uid + '"]'));
+                    removeScript(consent_managerBox.querySelector('[data-uid="script-' + uid + '"]'));
                 });
             }
         });


### PR DESCRIPTION
Bis zur 3.0.3 war es so, dass sofern man kein "consent_manager-show-box-reload" im Quelltext hatte, die Scripte nach Akzeptieren direkt nachgeladen wurden, ganz ohne Reload.

Ursache scheint mir eine Änderung der uid´s zu sein. Diese beginnen nun mit "script-".
In Zeile 63 wurde es bereits ensprechend angepasst, in den Zeilen 115 und 119 fehlte es noch.