### PR TITLE
PHP 8.1 - Bugfix

### DIFF
--- a/lib/consent_manager_clang.php
+++ b/lib/consent_manager_clang.php
@@ -54,7 +54,7 @@ class consent_manager_clang
                 if (!$page) {
                     continue;
                 }
-                $clang_id = str_replace('clang', '', rex_be_controller::getCurrentPagePart(3));
+                $clang_id = str_replace('clang', '', rex_be_controller::getCurrentPagePart(3, ''));
                 foreach (rex_clang::getAll() as $id => $clang)
                 {
                     $page->addSubpage((new rex_be_page('clang' . $id, $clang->getName()))


### PR DESCRIPTION
fixed #235 

Behebt diese Meldung
```
Deprecated
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
src/addons/consent_manager/lib/consent_manager_clang.php
```