### PR TITLE
Angabe eines Ports in domain ermöglichen

### DIFF
--- a/lib/consent_manager_rex_form.php
+++ b/lib/consent_manager_rex_form.php
@@ -74,6 +74,9 @@ class consent_manager_rex_form
 
     public static function validateHostname($hostname)
     {
+        if (str_contains($hostname, ':')) {
+            [$hostname, $port] = explode(':', $hostname, 2);
+        }
         return filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
     }
 


### PR DESCRIPTION
tauchte im Slack als Problem auf: 
"localhost:80" als domain eingeben zu können.