### PR TITLE
Warum soll das unverschlüsselte Übertragen von Cookies verboten sein?

### DIFF
--- a/assets/consent_manager_frontend.js
+++ b/assets/consent_manager_frontend.js
@@ -1,5 +1,5 @@
 const cmCookieExpires = 365;
-const cmCookieAPI = Cookies.withAttributes({ expires: cmCookieExpires, path: '/', domain: consent_manager_parameters.domain, sameSite: 'strict', secure: true });
+const cmCookieAPI = Cookies.withAttributes({ expires: cmCookieExpires, path: '/', domain: consent_manager_parameters.domain, sameSite: 'strict', secure: false });
 
 (function () {
     'use strict';


### PR DESCRIPTION
Hätte gern die Wahlmöglichkeit zurück.