### PR TITLE
Comment out logging for empty cookie groups

### DIFF
--- a/fragments/consent_manager_box_cssjs.php
+++ b/fragments/consent_manager_box_cssjs.php
@@ -44,7 +44,7 @@ if (isset($consent_manager->links['privacy_policy']) && isset($consent_manager->
 
 // Consent ausblenden wenn keine Dienste konfiguriert sind
 if (0 === count($consent_manager->cookiegroups)) {
-    rex_logger::factory()->log('warning', 'Addon consent_manager: Keine Cookie-Gruppen / Cookies ausgewählt bzw. keine Domain zugewiesen! (' . consent_manager_util::hostname() . ')');
+    //rex_logger::factory()->log('warning', 'Addon consent_manager: Keine Cookie-Gruppen / Cookies ausgewählt bzw. keine Domain zugewiesen! (' . consent_manager_util::hostname() . ')');
     $consentparams['initially_hidden'] = 'true';
 }
 


### PR DESCRIPTION
Soll einfach die häufigen nicht-zutreffenden Warnmeldungen im Log beenden.

closes #368 