### PR TITLE
Code-Überprüfung / Änderungsvorschlage (TODO: etc) / kleine Verbesserungen

### DIFF
--- a/fragments/ConsentManager/box.php
+++ b/fragments/ConsentManager/box.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * TODO: hier die Schnittstelle beschreiben: 
+ * - Welche Vars werden vom Fragment erwartet
+ * - Welchen Typ haben die Vars
+ * - Welchen Default-Wert haben optionale Vars
+ * - Welche Vars sind mandatory und was passiert wenn sie fehlen (return oder Exception)
+ */
+
 use FriendsOfRedaxo\ConsentManager\Frontend;
 
 $consent_manager = new Frontend(0);
@@ -10,7 +18,7 @@ if (0 === count($consent_manager->texts)) {
     echo '<div id="consent_manager-background">' . rex_view::error(rex_addon::get('consent_manager')->i18n('consent_manager_error_noconfig')) . '</div>';
     return;
 }
-if (null !== $consent_manager->cookiegroups): ?>
+if (0 < count($consent_manager->cookiegroups)) : ?>
         <div tabindex="-1" class="consent_manager-background consent_manager-hidden <?= $consent_manager->boxClass ?>" id="consent_manager-background" data-domain-name="<?= $consent_manager->domainName ?>" data-version="<?= $consent_manager->version ?>" data-consentid="<?= uniqid('', true) ?>" data-cachelogid="<?= $consent_manager->cacheLogId ?>" data-nosnippet aria-hidden="true">
             <div class="consent_manager-wrapper" id="consent_manager-wrapper" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="consent_manager-headline">
                 <div class="consent_manager-wrapper-inner">
@@ -21,6 +29,7 @@ if (null !== $consent_manager->cookiegroups): ?>
                             <?php
                             foreach ($consent_manager->cookiegroups as $cookiegroup) {
                                 if (count($cookiegroup['cookie_uids']) >= 1) {
+                                    // TODO: was steht eigentlch in dem Feld? String, Int, Bool, ...?
                                     if ($cookiegroup['required']) {
                                         echo '<div class="consent_manager-cookiegroup-checkbox">';
                                         echo '<label for="' . $cookiegroup['uid'] . '"><input type="checkbox" disabled="disabled" data-action="toggle-cookie" id="' . $cookiegroup['uid'] . '" data-uid="' . $cookiegroup['uid'] . '" data-cookie-uids=\'' . json_encode($cookiegroup['cookie_uids']) . '\' checked>';
@@ -66,7 +75,7 @@ if (null !== $consent_manager->cookiegroups): ?>
                                         if (isset($cookie['definition'])) {
                                             foreach ($cookie['definition'] as $def) {
                                                 $serviceName		= '';
-                                                if($cookie['service_name']) $serviceName = '('.$cookie['service_name'].')';
+                                                if('' !== ($cookie['service_name'] ?? '')) $serviceName = '('.$cookie['service_name'].')';
 
                                                 $linkTarget		=  '';
 												$linkRel		=  '';

--- a/fragments/ConsentManager/box_cssjs.php
+++ b/fragments/ConsentManager/box_cssjs.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * TODO: hier die Schnittstelle beschreiben: 
+ * - Welche Vars werden vom Fragment erwartet
+ * - Welchen Typ haben die Vars
+ * - Welchen Default-Wert haben optionale Vars
+ * - Welche Vars sind mandatory und was passiert wenn sie fehlen (return oder Exception)
+ */
+
 use FriendsOfRedaxo\ConsentManager\Frontend;
 
 /** @var rex_fragment $this */
@@ -51,8 +59,8 @@ if (0 < count($consent_manager->domainInfo)
         // Debug-Konfiguration für JavaScript verfügbar machen
         $googleConsentModeOutput .= '    <script>' . PHP_EOL;
         $googleConsentModeOutput .= '        window.consentManagerDebugConfig = ' . json_encode([
-            'mode' => $consent_manager->domainInfo['google_consent_mode_enabled'] ?? 'disabled',
-            'auto_mapping' => ($consent_manager->domainInfo['google_consent_mode_enabled'] ?? 'disabled') === 'auto',
+            'mode' => $consent_manager->domainInfo['google_consent_mode_enabled'],
+            'auto_mapping' => $consent_manager->domainInfo['google_consent_mode_enabled'] === 'auto',
             'debug_enabled' => true,
             'domain' => rex_request::server('HTTP_HOST'),
             'cache_log_id' => $consent_manager->cacheLogId,

--- a/fragments/ConsentManager/config_layout.php
+++ b/fragments/ConsentManager/config_layout.php
@@ -2,6 +2,14 @@
 /**
  * Fragment: Consent Manager Config Layout
  * Hauptlayout für die Konfigurationsseite.
+ * 
+ * 
+ * TODO: hier die Schnittstelle beschreiben: 
+ * - Welche Vars werden vom Fragment erwartet
+ * - Welchen Typ haben die Vars
+ * - Welchen Default-Wert haben optionale Vars
+ * - Welche Vars sind mandatory und was passiert wenn sie fehlen (return oder Exception)
+
  */
 
 /** @var rex_fragment $this */

--- a/fragments/ConsentManager/cookiedb.php
+++ b/fragments/ConsentManager/cookiedb.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * TODO: hier die Schnittstelle beschreiben: 
+ * - Welche Vars werden vom Fragment erwartet
+ * - Welchen Typ haben die Vars
+ * - Welchen Default-Wert haben optionale Vars
+ * - Welche Vars sind mandatory und was passiert wenn sie fehlen (return oder Exception)
+ */
+
 use FriendsOfRedaxo\ConsentManager\Frontend;
 
 /** @var rex_fragment $this */
@@ -11,7 +19,7 @@ if (is_string(rex_request::server('HTTP_HOST'))) {
 
 $output = '';
 
-if ($consent_manager->cookiegroups) { /** phpstan-ignore-line */
+if (0 !== count($consent_manager->cookiegroups)) { /** phpstan-ignore-line */
     // Cookie Consent + History
     $cookiedata = [];
     if (is_string(rex_request::cookie('consent_manager'))) {

--- a/fragments/ConsentManager/google_consent_helper.php
+++ b/fragments/ConsentManager/google_consent_helper.php
@@ -2,6 +2,12 @@
 /**
  * Fragment für Google Consent Mode v2 Helper
  * Generiert die HTML-Struktur für den Helper-Panel.
+ * 
+ * TODO: hier die Schnittstelle beschreiben: 
+ * - Welche Vars werden vom Fragment erwartet
+ * - Welchen Typ haben die Vars
+ * - Welchen Default-Wert haben optionale Vars
+ * - Welche Vars sind mandatory und was passiert wenn sie fehlen (return oder Exception)
  */
 
 ?>

--- a/fragments/ConsentManager/inline_cssjs.php
+++ b/fragments/ConsentManager/inline_cssjs.php
@@ -5,6 +5,12 @@
  *
  * Fragment für CSS/JS Integration der Inline-Consent-Funktion
  *
+ * TODO: hier die Schnittstelle beschreiben: 
+ * - Welche Vars werden vom Fragment erwartet
+ * - Welchen Typ haben die Vars
+ * - Welchen Default-Wert haben optionale Vars
+ * - Welche Vars sind mandatory und was passiert wenn sie fehlen (return oder Exception)
+ * 
  * @package redaxo\consent-manager
  */
 

--- a/lib/Api/ConsentManager.php
+++ b/lib/Api/ConsentManager.php
@@ -15,9 +15,9 @@ class ConsentManager extends rex_api_function
     protected $published = true;
 
     /**
-     * @return never
+     * @api
      */
-    public function execute(): void
+    public function execute(): never
     {
         $domain = rex_request::post('domain', 'string', false);
         $consentid = rex_request::post('consentid', 'string', false);

--- a/lib/CLang.php
+++ b/lib/CLang.php
@@ -119,9 +119,9 @@ class CLang
     {
         $db = rex_sql::factory();
         $db->setTable($form->getTableName());
-        $db->setWhere('pid = ' . $db->escape($params['sql']->getLastId())); /** @phpstan-ignore-line */
+        $db->setWhere('pid = :pid', [':pid'=> $params['sql']->getLastId()]);
         $db->select('*');
-        $inserted = $db->getArray()[0];
+        $inserted = $db->getArray()[0] ?? [];
         foreach (rex_clang::getAllIds() as $clangId) {
             if ((int) $inserted['clang_id'] === $clangId) {
                 continue;
@@ -143,10 +143,7 @@ class CLang
         }
     }
 
-    /**
-     * @param rex_form $form
-     */
-    private static function updateDataset($form): bool
+    private static function updateDataset(rex_form $form): bool
     {
         $fields2Update = [];
         $newValues = [];

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -126,7 +126,7 @@ class Cache
                 $cookie['definition'] = $defs;
                 $cookie['script'] = base64_encode($cookie['script']);
                 $cookie['script_unselect'] = base64_encode($cookie['script_unselect']);
-                $this->cookies[$clangId][$uid] = $cookie; /** @phpstan-ignore-line */
+                $this->cookies[$clangId][$uid] = $cookie;
             }
         }
     }
@@ -151,7 +151,7 @@ class Cache
                 $domainIds = array_filter(explode('|', $cookiegroup['domain']), strlen(...)); // @phpstan-ignore-line
                 foreach ($domainIds as $domainId) {
                     if (isset($this->domains[$domainId])) {
-                        $this->domains[$domainId]['cookiegroups'][] = $uid; /** @phpstan-ignore-line */
+                        $this->domains[$domainId]['cookiegroups'][] = $uid;
                     }
                 }
             }
@@ -162,19 +162,19 @@ class Cache
     {
         if (isset($this->cookiegroups[$clangId])) {
             foreach ((array) $this->cookiegroups[$clangId] as $v) {
-                $this->config['cookiegroups'][$v['clang_id']][$v['uid']] = $v; /** @phpstan-ignore-line */
+                $this->config['cookiegroups'][$v['clang_id']][$v['uid']] = $v;
             }
         }
         if (isset($this->cookies[$clangId])) {
             foreach ((array) $this->cookies[$clangId] as $v) {
-                $this->config['cookies'][$v['clang_id']][$v['uid']] = $v; /** @phpstan-ignore-line */
+                $this->config['cookies'][$v['clang_id']][$v['uid']] = $v;
             }
         }
         foreach ($this->domains as $v) {
-            $this->config['domains'][$v['uid']] = $v; /** @phpstan-ignore-line */
+            $this->config['domains'][$v['uid']] = $v;
         }
         if (isset($this->texts[$clangId])) {
-            $this->config['texts'][$clangId] = $this->texts[$clangId]; /** @phpstan-ignore-line */
+            $this->config['texts'][$clangId] = $this->texts[$clangId];
         }
         $this->config['majorVersion'] = rex_addon::get('consent_manager')->getVersion();
     }
@@ -190,12 +190,12 @@ class Cache
 
     /**
      * @api
-     * @return array<int, string>
+     * @return array<int|string, mixed>
      */
     public static function read(): array
     {
         $configFile = rex_path::addonData('consent_manager', 'config.json');
 
-        return rex_file::getCache($configFile);
+        return rex_file::getCache($configFile,[]);
     }
 }

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -9,10 +9,10 @@ class Config
     /**
      * get consent_manager tables.
      *
-     * @param bool $multilangOnly
+     * @api
      * @return array<int, string>
      */
-    public static function getTables($multilangOnly = false)
+    public static function getTables(bool $multilangOnly = false)
     {
         $tables = [];
         foreach (self::getKeys() as $key) {
@@ -28,7 +28,8 @@ class Config
     /**
      * get consent_manager keys.
      *
-     * @return array<int, string>
+     * @api
+     * @return string[]
      */
     public static function getKeys()
     {

--- a/lib/Cronjob/LogDelete.php
+++ b/lib/Cronjob/LogDelete.php
@@ -11,6 +11,9 @@ use rex_sql;
 
 class LogDelete extends rex_cronjob
 {
+    /**
+     * @api
+     */
     public function execute(): bool
     {
         if (rex_addon::get('consent_manager')->isAvailable()) {
@@ -33,12 +36,16 @@ class LogDelete extends rex_cronjob
         return false;
     }
 
+    /**
+     * @api
+     */
     public function getTypeName(): string
     {
         return rex_i18n::msg('consent_manager_cronjob_delete');
     }
 
     /**
+     * @api
      * @return list<array<string, mixed>>
      */
     public function getParamFields(): array

--- a/lib/Cronjob/ThumbnailCleanup.php
+++ b/lib/Cronjob/ThumbnailCleanup.php
@@ -11,18 +11,26 @@ use rex_cronjob;
  */
 class ThumbnailCleanup extends rex_cronjob
 {
+    /**
+     * @api
+     */
     public function execute(): bool
     {
         ThumbnailCache::cleanupCache();
         return true;
     }
 
+    /**
+     * @api
+     */
     public function getTypeName(): string
     {
+        /* TODO: Text nach *.lang verlagern (rex_18n) */
         return 'Consent Manager Thumbnail Cache bereinigen';
     }
 
     /**
+     * @api
      * @return list<array<string, mixed>>
      */
     public function getParamFields(): array

--- a/lib/GoogleConsentMode.php
+++ b/lib/GoogleConsentMode.php
@@ -59,6 +59,8 @@ class GoogleConsentMode
      * @api
      * @param string $domain Die Domain
      * @return array{enabled: bool, auto_mapping: bool, domain: string, flags: array<string, string>} Konfiguration mit enabled, auto_mapping, default_state etc
+     * 
+     * TODO: Domainen nicht als Array sondern als Objekt/Klasse? Erleichtert Übergaben als Parameter usw. 
      */
     public static function getDomainConfig(string $domain): array
     {
@@ -66,6 +68,7 @@ class GoogleConsentMode
         $domain = strtolower($domain);
 
         $sql = rex_sql::factory();
+        // TODO: umstellen auf setTable/setWhere/select
         $sql->setQuery(
             'SELECT google_consent_mode_enabled FROM ' . rex::getTable('consent_manager_domain') . ' WHERE uid = ?',
             [$domain],
@@ -91,7 +94,6 @@ class GoogleConsentMode
      * Holt Cookie-zu-Consent Mappings für eine Sprache.
      *
      * @api
-     * @param int $clangId Die Sprach-ID
      * @return array<string, array<string, string>> Array mit Service-UIDs und deren Consent-Flags
      */
     public static function getCookieConsentMappings(int $clangId): array
@@ -100,6 +102,7 @@ class GoogleConsentMode
 
         // Hole alle Services/Cookies
         $sql = rex_sql::factory();
+        // TODO: umstellen auf setTable/setWhere/select
         $sql->setQuery(
             'SELECT uid, service_name FROM ' . rex::getTable('consent_manager_cookie') . ' WHERE clang_id = ?',
             [$clangId],
@@ -129,9 +132,8 @@ class GoogleConsentMode
      * Generiert das JavaScript für Google Consent Mode v2.
      *
      * @api
-     * @param string $domain Die Domain
-     * @param int $clangId Die Sprach-ID
-     * @return string Das generierte JavaScript
+     * 
+     * TODO: Das JS besser via Fragment erzeugen? Wegen Übersichtlichkeit?
      */
     public static function generateJavaScript(string $domain, int $clangId): string
     {
@@ -198,8 +200,6 @@ class GoogleConsentMode
      * Prüft ob Google Consent Mode für eine Domain aktiviert ist.
      *
      * @api
-     * @param string $domain Die zu prüfende Domain
-     * @return bool True wenn aktiviert
      */
     public static function isDomainEnabled(string $domain): bool
     {
@@ -209,14 +209,14 @@ class GoogleConsentMode
 
     /**
      * Setzt den Google Consent Mode Status für eine Domain.
+     * Return true wenn erfolgreich
      *
      * @api
-     * @param string $domain Die Domain
      * @param string $mode Modus: 'disabled', 'auto', 'manual'
-     * @return bool True bei Erfolg
      */
     public static function setDomainEnabled(string $domain, string $mode): bool
     {
+        // TODO: validModes in den Klassenheader packen
         $validModes = ['disabled', 'auto', 'manual'];
         if (!in_array($mode, $validModes, true)) {
             return false;
@@ -247,10 +247,9 @@ class GoogleConsentMode
     }
 
     /**
-     * Fügt ein neues Service-Mapping hinzu.
+     * Fügt ein neues Service-Mapping für den Service-Schlüssel hinzu.
      *
      * @api
-     * @param string $serviceKey Service-Schlüssel
      * @param array<string> $consentFlags Array mit Consent-Flags
      */
     public static function addServiceMapping(string $serviceKey, array $consentFlags): void

--- a/lib/InlineConsent.php
+++ b/lib/InlineConsent.php
@@ -33,7 +33,8 @@ class InlineConsent
      * @param string $serviceKey Service-Schlüssel aus Consent Manager
      * @param string $content Original Content (iframe, script, etc.)
      * @param array<string, mixed> $options Zusätzliche Optionen
-     * @return string HTML-Output
+     * 
+     * TODO: Teste über .lang aufbauen
      */
     public static function doConsent(string $serviceKey, string $content, array $options = []): string
     {
@@ -41,6 +42,7 @@ class InlineConsent
         $service = self::getService($serviceKey);
         if (null === $service) {
             if (rex::isDebugMode()) {
+                // TODO: Text über die rex_view-Methoden aufbauen statt HTML
                 return '<div class="alert alert-warning">Consent Manager: Service "' . $serviceKey . '" nicht gefunden</div>';
             }
             return '<!-- Consent Manager: Service "' . $serviceKey . '" not found -->';
@@ -89,6 +91,7 @@ class InlineConsent
         $sql = rex_sql::factory();
 
         // Service aus der Cookie-Tabelle laden
+        // TODO: Query mit setTable/setWhere/select aufbauen
         $sql->setQuery('
             SELECT pid, id, clang_id, uid, service_name, provider, provider_link_privacy, 
                    definition, script, script_unselect, placeholder_text, placeholder_image,
@@ -271,6 +274,7 @@ class InlineConsent
         }
 
         // Alle Button-Texte für Fragment hinzufügen
+        // TODO: Button-Texte etc. über .lang bereitstellen
         $fragment->setVar('button_inline_details_text', self::getButtonText('button_inline_details', 'Einstellungen'));
         $fragment->setVar('inline_placeholder_text', self::getButtonText('inline_placeholder_text', 'Einmal laden'));
         $fragment->setVar('button_inline_allow_all_text', self::getButtonText('button_inline_allow_all', 'Alle erlauben'));
@@ -288,9 +292,7 @@ class InlineConsent
         // Icon-Konfiguration
         $fragment->setVar('privacy_icon', $options['privacy_icon'] ?? 'uk-icon:shield');
 
-        $result = $fragment->parse('ConsentManager/inline_placeholder.php');
-
-        return $result;
+        return $fragment->parse('ConsentManager/inline_placeholder.php');
     }
 
     /**
@@ -373,6 +375,7 @@ class InlineConsent
     public static function getJavaScript(): string
     {
         if (self::$jsOutputted) {
+            // TODO: wenn schon fester Text dann englisch
             return '<!-- JavaScript bereits ausgegeben -->';
         }
         self::$jsOutputted = true;
@@ -421,6 +424,7 @@ class InlineConsent
     public static function getCSS(): string
     {
         if (self::$cssOutputted) {
+            // TODO: wenn schon fester Text dann englisch
             return '<!-- CSS bereits ausgegeben -->';
         }
         self::$cssOutputted = true;

--- a/lib/JsonSetup.php
+++ b/lib/JsonSetup.php
@@ -31,6 +31,8 @@ class JsonSetup
      * @param bool $clearExisting Clear existing data before import
      * @param string $mode Import mode: 'replace' (default), 'update' (only add new)
      * @return array{success: bool, message: string} Result array with success status and message
+     * 
+     * TODO: Texte via .lang erzeugen?
      */
     public static function importSetup(string $jsonFile, bool $clearExisting = true, string $mode = 'replace'): array
     {
@@ -55,6 +57,7 @@ class JsonSetup
 
             // Begin transaction
             $sql = rex_sql::factory();
+            // TODO: warum nicht $sql->beginTransaction()?
             $sql->setQuery('START TRANSACTION');
 
             try {
@@ -70,6 +73,7 @@ class JsonSetup
                 self::importDomains($setupData['domains'] ?? [], $mode);
 
                 // Commit transaction
+                // Warum nicht $sql->Commit()
                 $sql->setQuery('COMMIT');
 
                 // Force cache rebuild
@@ -84,6 +88,8 @@ class JsonSetup
                 ];
             } catch (Exception $e) {
                 // Rollback on error
+                // TODO: warum nicht $sql->rollBack()
+                // Typ von $sql ist "never"? Seltsam
                 $sql->setQuery('ROLLBACK');
                 throw $e;
             }
@@ -353,6 +359,7 @@ class JsonSetup
     private static function findExistingCookieGroup(string $uid): ?array
     {
         $sql = rex_sql::factory();
+        // TODO: SQL-Abfrage auf setTable/setWhere/select umstellen
         $sql->setQuery('SELECT * FROM ' . rex::getTable('consent_manager_cookiegroup') . ' WHERE uid = ?', [$uid]);
         return $sql->getRows() > 0 ? $sql->getRow() : null;
     }
@@ -363,6 +370,7 @@ class JsonSetup
     private static function findExistingCookie(string $uid): ?array
     {
         $sql = rex_sql::factory();
+        // TODO: SQL-Abfrage auf setTable/setWhere/select umstellen
         $sql->setQuery('SELECT * FROM ' . rex::getTable('consent_manager_cookie') . ' WHERE uid = ?', [$uid]);
         return $sql->getRows() > 0 ? $sql->getRow() : null;
     }
@@ -373,6 +381,7 @@ class JsonSetup
     private static function findExistingText(string $uid, int $clangId = 1): ?array
     {
         $sql = rex_sql::factory();
+        // TODO: SQL-Abfrage auf setTable/setWhere/select umstellen
         $sql->setQuery('SELECT * FROM ' . rex::getTable('consent_manager_text') . ' WHERE uid = ? AND clang_id = ?', [$uid, $clangId]);
         return $sql->getRows() > 0 ? $sql->getRow() : null;
     }
@@ -383,6 +392,7 @@ class JsonSetup
     private static function findExistingDomain(string $uid): ?array
     {
         $sql = rex_sql::factory();
+        // TODO: SQL-Abfrage auf setTable/setWhere/select umstellen
         $sql->setQuery('SELECT * FROM ' . rex::getTable('consent_manager_domain') . ' WHERE uid = ?', [$uid]);
         return $sql->getRows() > 0 ? $sql->getRow() : null;
     }
@@ -395,9 +405,7 @@ class JsonSetup
     private static function insertCookieGroup(array $group): void
     {
         $sql = rex_sql::factory();
-        /** @var non-empty-string $tableName */
-        $tableName = 'consent_manager_cookiegroup';
-        $sql->setTable(rex::getTable($tableName));
+        $sql->setTable(rex::getTable('consent_manager_cookiegroup'));
 
         $now = date('Y-m-d H:i:s');
 
@@ -437,6 +445,7 @@ class JsonSetup
     private static function idExistsInTable(string $table, int $id): bool
     {
         $sql = rex_sql::factory();
+        // TODO: SQL-Abfrage auf setTable/setWhere/select umstellen
         $sql->setQuery('SELECT COUNT(*) as count FROM ' . rex::getTable($table) . ' WHERE id = ?', [$id]);
         return $sql->getValue('count') > 0;
     }
@@ -447,6 +456,7 @@ class JsonSetup
     private static function getNextAvailableId(string $table): int
     {
         $sql = rex_sql::factory();
+        // TODO: SQL-Abfrage auf setTable/setWhere/select umstellen
         $sql->setQuery('SELECT MAX(id) as max_id FROM ' . rex::getTable($table));
         $maxId = (int) ($sql->getValue('max_id') ?? 0);
         return $maxId + 1;
@@ -458,9 +468,7 @@ class JsonSetup
     private static function insertCookie(array $cookie): void
     {
         $sql = rex_sql::factory();
-        /** @var non-empty-string $tableName */
-        $tableName = 'consent_manager_cookie';
-        $sql->setTable(rex::getTable($tableName));
+        $sql->setTable(rex::getTable('consent_manager_cookie'));
 
         $now = date('Y-m-d H:i:s');
 

--- a/lib/RexFormSupport.php
+++ b/lib/RexFormSupport.php
@@ -6,6 +6,7 @@ use rex_extension_point;
 use rex_form;
 use rex_sql;
 use rex_string;
+use rex_view;
 use rex_yaml_parse_exception;
 
 use function in_array;
@@ -16,11 +17,11 @@ use const FILTER_VALIDATE_DOMAIN;
 class RexFormSupport
 {
     /**
-     * @param string $label
-     * @param string $value
-     * @return string
+     * @api
+     * 
+     * TODO: korrekter Weise müsste das wohl mit dem Fragment core/form/form.php gelöst werden.
      */
-    public static function getFakeText($label, $value)
+    public static function getFakeText(string $label, string $value): string
     {
         $html = '';
         $html .= '<dl class="rex-form-group form-group consent_manager-fake">';
@@ -31,11 +32,10 @@ class RexFormSupport
     }
 
     /**
-     * @param string $label
-     * @param string $value
-     * @return string
+     * @api
+     * TODO: korrekter Weise müsste das wohl mit dem Fragment core/form/form.php gelöst werden.
      */
-    public static function getFakeTextarea($label, $value)
+    public static function getFakeTextarea(string $label, string $value): string
     {
         $html = '';
         $html .= '<dl class="rex-form-group form-group consent_manager-fake">';
@@ -46,11 +46,11 @@ class RexFormSupport
     }
 
     /**
-     * @param string $label
+     * @api
      * @param array<string, string> $checkboxes
-     * @return string
+     * TODO: korrekter Weise müsste das wohl mit dem Fragment core/form/checkbox.php gelöst werden.
      */
-    public static function getFakeCheckbox($label, $checkboxes)
+    public static function getFakeCheckbox(string $label, array $checkboxes): string
     {
         $html = '';
         $html .= '<dl class="rex-form-group form-group consent_manager-fake">';
@@ -68,11 +68,10 @@ class RexFormSupport
     }
 
     /**
-     * @param rex_form $form
-     * @param string $table
-     * @return void
+     * @api
+     * @param non-empty-string $table
      */
-    public static function getId(&$form, $table)
+    public static function getId(rex_form $form, string $table): void
     {
         if (!$form->isEditMode()) {
             $db = rex_sql::factory();
@@ -84,35 +83,35 @@ class RexFormSupport
     }
 
     /**
-     * @param rex_extension_point<object> $ep
-     * @return void
      * @api
+     * @param rex_extension_point<array<string,string>> $ep
      */
-    public static function removeDeleteButton(rex_extension_point $ep)
+    public static function removeDeleteButton(rex_extension_point $ep): void
     {
-        $formTable = $ep->getParams()['form']->getTableName();
+        /** @var rex_form $form */
+        $form = $ep->getParam('form');
+        $formTable = $form->getTableName();
         if (in_array($formTable, Config::getTables(), true)) {
             $subject = $ep->getSubject();
-            $subject['delete'] = ''; /** @phpstan-ignore-line */
+            $subject['delete'] = '';
             $ep->setSubject($subject);
         }
     }
 
     /**
-     * @param string $msg
-     * @return string
+     * @api
      */
-    public static function showInfo($msg)
+    public static function showInfo(string $msg): string
     {
+        // TODO: Ausgabe mit rex_view, kein direktes HTML ... wenn das geht.
         return '<div class="consent_manager-rex-form-info"><i class="fa fa-info-circle"></i>' . $msg . '</div>';
     }
 
     /**
-     * @param string $hostname
-     * @return bool|string
      * @api
+     * @param string $hostname
      */
-    public static function validateHostname($hostname)
+    public static function validateHostname(string $hostname): bool|string
     {
         $host = parse_url('https://' . $hostname);
         if (isset($host['scheme']) && isset($host['host']) && !isset($host['path'])) {
@@ -122,22 +121,19 @@ class RexFormSupport
     }
 
     /**
-     * @param string $value
-     * @return bool
+     * Prüft ob der Wert nur Kleinbuchstaben enthält
+     * 
      * @api
      */
-    public static function validateLowercase($value)
+    public static function validateLowercase(string $value): bool
     {
-        // Prüft ob der Wert nur Kleinbuchstaben enthält
         return $value === strtolower($value);
     }
 
     /**
-     * @param string $yaml
-     * @return bool
      * @api
      */
-    public static function validateYaml($yaml)
+    public static function validateYaml(string $yaml): bool
     {
         $valid = true;
         try {

--- a/lib/RexListSupport.php
+++ b/lib/RexListSupport.php
@@ -10,11 +10,10 @@ class RexListSupport
     /**
      * format domains.
      *
-     * @param array<string, string> $params
-     * @return string
      * @api
+     * @param array<string, string> $params
      */
-    public static function formatDomain($params)
+    public static function formatDomain($params): string
     {
         $ids = array_map(trim(...), explode('|', $params['value']));
         $ids = array_filter($ids, strlen(...)); // @phpstan-ignore-line
@@ -37,11 +36,10 @@ class RexListSupport
     /**
      * format cookies.
      *
-     * @param array<string, string> $params
-     * @return string
      * @api
+     * @param array<string, string> $params
      */
-    public static function formatCookie($params)
+    public static function formatCookie($params): string
     {
         if (isset($params['value'])) {
             $uids = array_map(trim(...), explode('|', $params['value']));

--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -53,9 +53,8 @@ class Theme
 
     /**
      * Get compiled scss.
-     * @return string|false
      */
-    public function getCompiledStyle(string $theme = '')
+    public function getCompiledStyle(string $theme = ''): string|false
     {
         if ('' === $theme) {
             $theme = $this->getTheme();
@@ -133,7 +132,7 @@ class Theme
      * Get theme info from file.
      * @return array<string, string>
      */
-    public function getThemeInformation(string $theme = '')
+    public function getThemeInformation(string $theme = ''): array
     {
         if ('' === $theme) {
             $theme = $this->getTheme();
@@ -155,6 +154,6 @@ class Theme
             }
         }
         $themeinfo = (array) json_decode($json, true);
-        return $themeinfo; /** @phpstan-ignore-line */
+        return $themeinfo;
     }
 }

--- a/lib/ThumbnailCache.php
+++ b/lib/ThumbnailCache.php
@@ -179,6 +179,8 @@ class ThumbnailCache
 
     /**
      * Platzhalter-Bild generieren.
+     * 
+     * TODO: prüfen, ob man hier nicht auch auf ein Fragment setzen sollte; kein Ausgabecode im Programm selbst...
      */
     private static function getPlaceholderImage(string $service): string
     {
@@ -215,10 +217,11 @@ class ThumbnailCache
 
     /**
      * Cache aufräumen (alte Dateien löschen).
+     * Default: 30 Tage
      *
      * @api
      */
-    public static function cleanupCache(int $maxAge = 2592000): void // 30 Tage
+    public static function cleanupCache(int $maxAge = 2592000): void
     {
         $cacheDir = self::getCacheDir();
         $publicCacheDir = rex_path::addonAssets('consent_manager', 'cache/thumbnails/');

--- a/lib/ThumbnailMediaManager.php
+++ b/lib/ThumbnailMediaManager.php
@@ -27,6 +27,8 @@ class ThumbnailMediaManager
      * @param string $videoId Video-ID
      * @param array<string, mixed> $options Zusätzliche Optionen
      * @return string|null Thumbnail-URL oder null bei Fehler
+     * 
+     * TODO: prüfen, warum hier $options vorkommt. Der Parameter wird im Code nicht benutzt.
      */
     public static function getThumbnailUrl(string $service, string $videoId, array $options = []): ?string
     {
@@ -37,6 +39,7 @@ class ThumbnailMediaManager
 
         // Prüfen ob unser Mediamanager-Type existiert
         $sql = rex_sql::factory();
+        // TODO: Query in setTable/setWhere/select ändern
         $sql->setQuery('SELECT id FROM ' . rex::getTable('media_manager_type') . ' WHERE name = ?', ['consent_manager_thumbnail']);
 
         if (0 === $sql->getRows()) {
@@ -174,12 +177,11 @@ class ThumbnailMediaManager
     }
 
     /**
-     * Thumbnail-URL aus Video-URL generieren.
+     * Thumbnail-URL aus Video-URL (YouTube oder Vimeo) generieren.
+     * NULL bei ungültiger URL
      *
      * @api
-     * @param string $videoUrl YouTube oder Vimeo URL
      * @param array<string, mixed> $options Zusätzliche Optionen
-     * @return string|null Thumbnail-URL oder null bei ungültiger URL
      */
     public static function getThumbnailUrlFromVideoUrl(string $videoUrl, array $options = []): ?string
     {
@@ -194,6 +196,8 @@ class ThumbnailMediaManager
 
     /**
      * Direkte Thumbnail-URL als Fallback.
+     * 
+     * TODO: prüfen, ob nicht ein Fragment für die SVGs besser wäre
      */
     private static function getDirectThumbnailUrl(string $service, string $videoId): string
     {

--- a/lib/Utility.php
+++ b/lib/Utility.php
@@ -17,10 +17,9 @@ class Utility
     /**
      * Check consent for cookieUid.
      *
-     * @param string $cookieUid
      * @api
      */
-    public static function has_consent($cookieUid): bool
+    public static function has_consent(string $cookieUid): bool
     {
         if (null !== rex_request::cookie('consent_manager') && is_string(rex_request::cookie('consent_manager'))) {
             $cookieData = (array) json_decode(rex_request::cookie('consent_manager'), true);
@@ -37,6 +36,7 @@ class Utility
 
     /**
      * Check if consent is configured.
+     * 
      * @api
      */
     public static function consentConfigured(): bool
@@ -45,6 +45,7 @@ class Utility
         $db->setDebug(false);
 
         // Check host
+        // TODO: setTable/setWhere/select
         $db->prepareQuery('SELECT `id` FROM `' . rex::getTable('consent_manager_domain') . '` WHERE `uid` = :uid');
         $dbresult = $db->execute(['uid' => rex_request::server('HTTP_HOST')]);
         if (1 === $dbresult->getRows()) {
@@ -63,6 +64,7 @@ class Utility
      * Hostname WITH subdomain (DSGVO-konform).
      * Returns full hostname including subdomain to ensure consent is domain-specific.
      * Issue #317: Subdomain consent must be separate from main domain consent.
+     * 
      * @api
      */
     public static function hostname(): string
@@ -76,9 +78,10 @@ class Utility
     }
 
     /**
-     * Daomain info from Url.
-     * @return array<string, string>
+     * Domain info from Url.
+     * 
      * @api
+     * @return array<string, string>
      */
     public static function get_domaininfo(string $url): array
     {
@@ -92,7 +95,7 @@ class Utility
         $parts = explode('.', $matches[2]);
         $tld = array_pop($parts);
         $host = array_pop($parts);
-        if (2 === strlen($tld) && strlen($host) <= 3) { /** @phpstan-ignore-line */
+        if (2 === strlen($tld) && strlen($host) <= 3) {
             $tld = "$host.$tld";
             $host = array_pop($parts);
         }

--- a/lib/effect_external_thumbnail.php
+++ b/lib/effect_external_thumbnail.php
@@ -25,7 +25,8 @@ class rex_effect_external_thumbnail extends rex_effect_abstract
 
     /**
      * @api
-     * @return void
+     * 
+     * TODO: Prüfen,ob die (engl.) Meldungen weiter im Test stehen oder nach .lang übertragen werden
      */
     public function execute()
     {
@@ -204,6 +205,8 @@ class rex_effect_external_thumbnail extends rex_effect_abstract
 
     /**
      * Download mit cURL.
+     * 
+     * TODO: Prüfen,ob die (engl.) Meldungen weiter im Test stehen oder nach .lang übertragen werden
      */
     private function downloadWithCurl(string $url): ?string
     {
@@ -248,6 +251,8 @@ class rex_effect_external_thumbnail extends rex_effect_abstract
 
     /**
      * Download mit file_get_contents (Fallback).
+     * 
+     * TODO: Prüfen,ob die (engl.) Meldungen weiter im Test stehen oder nach .lang übertragen werden
      */
     private function downloadWithFileGetContents(string $url): ?string
     {
@@ -298,8 +303,9 @@ class rex_effect_external_thumbnail extends rex_effect_abstract
 
     /**
      * @api
-     * @return string
-     */
+     * 
+     * TODO: Prüfen,ob die (engl.) Meldungen weiter im Test stehen oder nach .lang übertragen werden
+    */
     public function getName(): string
     {
         return 'External Thumbnail';
@@ -308,6 +314,8 @@ class rex_effect_external_thumbnail extends rex_effect_abstract
     /**
      * @api
      * @return list<array{label: string, name: string, type: 'float'|'int'|'media'|'select'|'string', default?: mixed, notice?: string, prefix?: string, suffix?: string, attributes?: array<string, mixed>}>
+     * 
+     * TODO: Prüfen,ob die (engl.) Meldungen weiter im Test stehen oder nach .lang übertragen werden
      */
     public function getParams(): array
     {

--- a/pages/log.php
+++ b/pages/log.php
@@ -49,13 +49,15 @@ $list->setColumnLabel('cachelogid', rex_i18n::msg('consent_manager_thead_cachelo
 $list->setColumnLabel('consentid', rex_i18n::msg('consent_manager_thead_consentid'));
 
 $list->setColumnFormat('createdate', 'custom', static function ($params) {
+    /** @var rex_list $list */
     $list = $params['list'];
-    $str = date('d.m.Y H:i:s', strtotime($list->getValue('createdate')));
+    $str = date('d.m.Y H:i:s', (int) strtotime((string) $list->getValue('createdate')));
     return $str;
 });
 $list->setColumnFormat('consents', 'custom', static function ($params) {
+    /** @var rex_list $list */
     $list = $params['list'];
-    $consents = (array) json_decode($list->getValue('consents'));
+    $consents = (array) json_decode((string) $list->getValue('consents'));
     $str = implode(', ', $consents);
     return $str;
 });


### PR DESCRIPTION
- kleinere Änderungen im Code insb. als Reaktion auf RexStan-Analysen (z.B. `if (null !== $xyz)` statt `if ($xyz)`
- Datentypen im Methodenheader festgelegt statt mittels PHPDoc.
- TODOs: an zahlreichen Stellen habe ich lediglich TODO-Anmerkungen platziert. Ich wollte hier nicht zu viele substanzielle Änderungen machen, die einen einzelnen PR zu sehr aufblähen. Die TODOs sind oft auch Punkte, die jemand mit Fachkenntnis zum Addon beuteilen müsste. Sowas wie "Warum hat die Methode Parameter, die dann doch nicht benutzt werden. Kann das weg?"

Das Weitere kann dann in thematisch abgeschlossenen PRs bearbeitet werden. Beispiele
- in den Fragmenten im Header die erwarteten Vars beschreiben
- die `$sql->setQuery` durch einzelne Methoden setTable/setWhere/select ersetzen
- komplexere Array (Domeine, Cookie) mit Klassen abwickeln, dann wird auch der Folgecod eeinfacher, weil dort nicht immer wieder auf die Existenz oder den Datentyp einzelner Array-Elemente geprüft werden muss.
- Schauen, was in Fragmente ausgelagert werden kann, damit die Trennung zwischen Code und Ausgabe besser wird. Insb. die Code-Stellen, die JS erzeugen. 

Dafpr brauche ich aber erstmal Feedback.