### PR TITLE
TODOS bzgl rex_view als Ausgabe umgesetzt; Kommentare aktualisiert

### DIFF
--- a/lib/InlineConsent.php
+++ b/lib/InlineConsent.php
@@ -17,6 +17,7 @@ use rex_fragment;
 use rex_sql;
 use rex_sql_exception;
 use rex_url;
+use rex_view;
 
 use function is_array;
 use function strlen;
@@ -33,8 +34,6 @@ class InlineConsent
      * @param string $serviceKey Service-Schlüssel aus Consent Manager
      * @param string $content Original Content (iframe, script, etc.)
      * @param array<string, mixed> $options Zusätzliche Optionen
-     * 
-     * TODO: Teste über .lang aufbauen
      */
     public static function doConsent(string $serviceKey, string $content, array $options = []): string
     {
@@ -42,9 +41,10 @@ class InlineConsent
         $service = self::getService($serviceKey);
         if (null === $service) {
             if (rex::isDebugMode()) {
-                // TODO: Text über die rex_view-Methoden aufbauen statt HTML
-                return '<div class="alert alert-warning">Consent Manager: Service "' . $serviceKey . '" nicht gefunden</div>';
+                // TODO: Texte über .lang aufbauen
+                return rex_view::warning('Consent Manager: Service "' . htmlspecialchars($serviceKey) . '" nicht gefunden');
             }
+            // TODO: Texte über .lang aufbauen?
             return '<!-- Consent Manager: Service "' . $serviceKey . '" not found -->';
         }
 
@@ -286,6 +286,7 @@ class InlineConsent
         $fragment->setVar('inline_privacy_link_text', self::getButtonText('inline_privacy_link_text', 'Datenschutzerklärung von'));
 
         if ($debug) {
+            // TODO: Texte über .lang aufbauen?
             echo "<!-- DEBUG inline_privacy_notice from DB: $privacyNotice -->\n";
         }
 
@@ -326,6 +327,7 @@ class InlineConsent
             }
 
             if ('' !== $videoId) {
+                // TODO: Verlagerung in ein Fragment prüfen
                 // Standard YouTube iframe
                 $width = $options['width'] ?? '560';
                 $height = $options['height'] ?? '315';
@@ -347,6 +349,7 @@ class InlineConsent
             }
 
             if ('' !== $videoId) {
+                // TODO: Verlagerung in ein Fragment prüfen
                 // Standard Vimeo iframe
                 $width = $options['width'] ?? '640';
                 $height = $options['height'] ?? '360';
@@ -358,6 +361,7 @@ class InlineConsent
 
         // Für Google Maps Embed URLs: In iframe umwandeln
         if (str_contains($content, 'google.com/maps/embed')) {
+            // TODO: Verlagerung in ein Fragment prüfen
             return '<iframe src="' . rex_escape($content) . '" 
                     width="' . ($options['width'] ?? '100%') . '" height="' . ($options['height'] ?? '450') . '" 
                     style="border:0;" allowfullscreen="" loading="lazy"' . $attributesString . '></iframe>';
@@ -375,7 +379,7 @@ class InlineConsent
     public static function getJavaScript(): string
     {
         if (self::$jsOutputted) {
-            // TODO: wenn schon fester Text dann englisch
+            // TODO: wenn schon fester Text dann englisch; oder .lang
             return '<!-- JavaScript bereits ausgegeben -->';
         }
         self::$jsOutputted = true;
@@ -400,15 +404,18 @@ class InlineConsent
             if ($sql->getRows() > 0) {
                 $value = (string) $sql->getValue('text');
                 if ($debug) {
+                    // TODO: Texte über .lang aufbauen?
                     echo "<!-- DEBUG getButtonText: key=$key, clang=" . rex_clang::getCurrentId() . ", value=$value -->\n";
                 }
                 return $value;
             }
             if ($debug) {
+                // TODO: Texte über .lang aufbauen?
                 echo "<!-- DEBUG getButtonText: key=$key NOT FOUND in DB, using fallback=$fallback -->\n";
             }
         } catch (rex_sql_exception $e) {
             if ($debug) {
+                // TODO: Texte über .lang aufbauen?
                 echo "<!-- DEBUG getButtonText: key=$key, SQL ERROR: " . $e->getMessage() . " -->\n";
             }
         }

--- a/lib/OEmbedParser.php
+++ b/lib/OEmbedParser.php
@@ -22,6 +22,7 @@ use rex_extension_point;
 use rex_request;
 use rex_sql;
 use rex_sql_exception;
+use rex_view;
 
 use function is_string;
 
@@ -107,6 +108,7 @@ class OEmbedParser
         if (null === $platform) {
             // Unbekannte Plattform - Original zurückgeben oder Fehler
             if (rex::isDebugMode()) {
+                // TODO: Texte über .lang aufbauen
                 return '<!-- Consent Manager oEmbed: Unsupported platform for URL: ' . htmlspecialchars($url) . ' -->';
             }
             return '';
@@ -119,8 +121,8 @@ class OEmbedParser
         // Prüfe ob Service in Consent Manager existiert
         if (!self::serviceExists($serviceKey)) {
             if (rex::isDebugMode()) {
-                // TODO: mit rex_view formatieren statt HTML zu schreiben
-                return '<div class="alert alert-warning">Consent Manager: Service "' . htmlspecialchars($serviceKey) . '" nicht konfiguriert</div>';
+                // TODO: Texte über .lang aufbauen
+                return rex_view::warning('Consent Manager: Service "' . htmlspecialchars($serviceKey) . '" nicht konfiguriert');
             }
             return '';
         }
@@ -281,6 +283,7 @@ class OEmbedParser
     {
         // Prüfe ob Vidstack Addon verfügbar ist
         if (!rex_addon::exists('vidstack') || !rex_addon::get('vidstack')->isAvailable()) {
+            // TODO: Texte über .lang aufbauen
             return '<!-- Vidstack Player nicht verfügbar -->';
         }
 
@@ -308,8 +311,10 @@ class OEmbedParser
             return $player->generate();
         } catch (Exception $e) {
             if (rex::isDebugMode()) {
+                // TODO: Texte über .lang aufbauen
                 return '<!-- Vidstack Error: ' . htmlspecialchars($e->getMessage()) . ' -->';
             }
+                // TODO: Texte über .lang aufbauen
             return '<!-- Vidstack Error -->';
         }
     }

--- a/lib/RexFormSupport.php
+++ b/lib/RexFormSupport.php
@@ -103,8 +103,7 @@ class RexFormSupport
      */
     public static function showInfo(string $msg): string
     {
-        // TODO: Ausgabe mit rex_view, kein direktes HTML ... wenn das geht.
-        return '<div class="consent_manager-rex-form-info"><i class="fa fa-info-circle"></i>' . $msg . '</div>';
+        return rex_view::info('<i class="fa fa-info-circle"></i> ' . htmlspecialchars($msg), 'consent_manager-rex-form-info');
     }
 
     /**


### PR DESCRIPTION
Aus Issue 419 schon mal Kleinkram angegangen:

die TODOs bzgl der Umstellung von diskretem Code (`<div class="alert alert-warning">...`) auf rex_view (`rex_view::warning(...`.

Die dazugehörigen  TODO-Kommentare entfernt.

Beifang: die .lang betreffenden TODO-Kommentare zielgerichteter platziert und nicht nur allgemein.