### PR TITLE
default value for inline parameter ist inkorrekt

### DIFF
--- a/fragments/ConsentManager/box_cssjs.php
+++ b/fragments/ConsentManager/box_cssjs.php
@@ -22,7 +22,8 @@ if (true === rex_request::get('consent_manager_outputjs', 'bool', false)) {
 $addon = rex_addon::get('consent_manager');
 $forceCache = $this->getVar('forceCache');
 $forceReload = $this->getVar('forceReload');
-$inlineMode = $this->getVar('inline', false);
+// Default null statt false: nur true/'true'/'1' wird später geprüft, false würde zu Verwirrung führen
+$inlineMode = $this->getVar('inline', null);
 
 $consentparams = [];
 $consentparams['article'] = rex_article::getCurrentId();


### PR DESCRIPTION
Change default value of inline parameter from false to null.

Schau dir (oder lass schauen) den Codeblock ab Zeile 89 noch mal an.

$explicitInlineParam ist im Moment auch true, wenn der Parameter gar nicht gesetzt ist.
(default -> $inlineParam = false => $explicitInlineParam = true)