### PR TITLE
role ergänzt

### DIFF
--- a/fragments/ConsentManager/box.php
+++ b/fragments/ConsentManager/box.php
@@ -102,7 +102,7 @@ if (0 < count($consent_manager->cookiegroups)) : ?>
                         </div>
                     </div>
 
-                    <div class="consent_manager-detail consent_manager-hidden" id="consent_manager-detail" aria-labelledby="consent_manager-toggle-details">
+                    <div class="consent_manager-detail consent_manager-hidden" id="consent_manager-detail" aria-labelledby="consent_manager-toggle-details" role="region">
                     	<?php
                         foreach ($consent_manager->cookiegroups as $cookiegroup) {
                             if (count($cookiegroup['cookie_uids']) >= 1) {


### PR DESCRIPTION
w3c lieferte einen Fehler

> Error: The aria-labelledby attribute must not be specified on any div element unless the element has a role value other than caption, code, deletion, emphasis, generic, insertion, paragraph, presentation, strong, subscript, or superscript.

> `<div class="consent_manager-detail consent_manager-hidden" id="consent_manager-detail" aria-labelledby="consent_manager-toggle-details">`