### PR TITLE
 fix: Text-Unterseite für texteditonly-Benutzer nicht sichtbar

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -28,7 +28,6 @@ page:
     text:
       title: "translate:consent_manager_texts"
       icon: rex-icon fa-file-text-o
-      perm: consent_manager[config]
     domain:
       title: "translate:consent_manager_domains"
       icon: rex-icon fa-globe


### PR DESCRIPTION

  ## Problem
  Benutzer mit der Rolle `consent_manager[texteditonly]` sehen die Unterseite
  im Backend nicht, obwohl sie sollten.

  ## Ursache
  Die Unterseite `text` in `package.yml` hat `perm: consent_manager[config]`.
  Dieser Berechtigungs-Check greift bevor `boot.php` die anderen Seiten
  ausblendet — texteditonly-Benutzer sehen daher gar nichts.

  ## Lösung
  `perm: consent_manager[config]` beim `text`-Eintrag entfernt.
  Die `boot.php` beschränkt texteditonly-Benutzer bereits korrekt auf diese Seite.
