### PR TITLE
fix(a11y): inline placeholder title uses <p>, not <h4>

### DIFF
--- a/fragments/ConsentManager/inline_placeholder.php
+++ b/fragments/ConsentManager/inline_placeholder.php
@@ -79,7 +79,7 @@ if (str_starts_with($iconClass, 'uk-icon:')) {
 }
 ?>
                     </div>
-                    <h4 class="consent-inline-title"><?= rex_escape($options['title'] ?? $service['service_name'] ?? $inline_title_fallback) ?></h4>
+                    <p class="consent-inline-title h4"><?= rex_escape($options['title'] ?? $service['service_name'] ?? $inline_title_fallback) ?></p>
                     <p class="consent-inline-notice"><?= rex_escape($options['privacy_notice'] ?? (isset($service['placeholder_text']) && '' !== $service['placeholder_text'] ? $service['placeholder_text'] : $inline_privacy_notice)) ?></p>
                     <p class="consent-inline-action-text"><?= rex_escape($inline_action_text) ?></p>
                     


### PR DESCRIPTION
## Summary

The inline placeholder rendered by `InlineConsent::renderPlaceholderHTML()` hard-wires a `<h4>` for the service title (`fragments/ConsentManager/inline_placeholder.php`). When the placeholder is rendered inside arbitrary page content, this almost always breaks the document outline: a `<section>` already running on `<h2>` / `<h3>` suddenly contains a stray `<h4>` with no parent heading. Lighthouse and other a11y audits flag this as a heading-order issue (we noticed it dropping our score on a fully-clean page from 100 to 98).

This PR switches the tag to `<p>` so the placeholder no longer participates in the heading outline, while keeping `.consent-inline-title` plus the Bootstrap-style `.h4` utility class so themes that style by either selector stay visually identical.

## Change

```diff
- <h4 class="consent-inline-title">…</h4>
+ <p class="consent-inline-title h4">…</p>
```

- `assets/consent_inline.css` targets `.consent-inline-title` (class only, not tag) → no CSS update needed, visual rendering unchanged.
- The bundled `box_bootstrap5.php` already uses the same `class="… h4 …"` pattern on non-heading elements, so adding `.h4` here is consistent with the addon.
- Themes that **do** want a real heading can still override the fragment via `theme/private/fragments/ConsentManager/inline_placeholder.php` (REDAXO fragment override).

## Test plan

- [ ] Inline placeholder still renders the title text in the same visual style across the bundled box variants (default, bootstrap5, uikit3, bulma).
- [ ] Lighthouse "Heading elements appear in a sequentially-descending order" no longer flags pages embedding the placeholder.
- [ ] Existing CSS overrides targeting `.consent-inline-title` keep working (class-only selectors).