### PR TITLE
fix(inline): four small bugs around the inline-consent flow

### DIFF
--- a/assets/consent_inline.css
+++ b/assets/consent_inline.css
@@ -65,7 +65,7 @@
     --consent-overlay-border-radius: 8px;
     --consent-overlay-border: 1px solid rgba(128, 128, 128, 0.2);
     --consent-overlay-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-    --consent-overlay-max-width: 90%;
+    --consent-overlay-max-width: 100%;
     
     position: relative;
     z-index: 2;
@@ -258,7 +258,7 @@
         /* Mobile Variablen */
         --consent-min-height: 250px;
         --consent-overlay-padding: 1.5rem;
-        --consent-overlay-max-width: 95%;
+        --consent-overlay-max-width: 100%;
     }
     
     .consent-inline-content {

--- a/assets/consent_inline.js
+++ b/assets/consent_inline.js
@@ -556,9 +556,15 @@ if (typeof window.consentManagerInline !== 'undefined') {
                 this.clearOldConsentCookies();
             }
 
+            // Legacy-Cleanup: in v5.6.6 und früher wurde das Cookie unter dem
+            // falschen Namen 'consent_manager' geschrieben, alle Read-Pfade
+            // verwendeten aber 'consentmanager'. Den alten Namen für betroffene
+            // User explizit löschen, damit nicht zwei parallele Cookies existieren.
+            document.cookie = 'consent_manager=; expires=' + new Date(0).toUTCString() + '; path=/';
+
             // Setze das neue Cookie (neu und sauber)
-            document.cookie = 'consent_manager=' + JSON.stringify(data) + 
-                             '; expires=' + expires.toUTCString() + 
+            document.cookie = 'consentmanager=' + JSON.stringify(data) +
+                             '; expires=' + expires.toUTCString() +
                              '; path=/; SameSite=Lax';
         },
         

--- a/assets/consent_inline.js
+++ b/assets/consent_inline.js
@@ -585,7 +585,27 @@ if (typeof window.consentManagerInline !== 'undefined') {
                     return null;
                 }
             }
-            return this.getCookie('consentmanager');
+            var raw = this.getCookie('consentmanager');
+            if (raw !== null) {
+                return raw;
+            }
+            // Legacy-Migration: in v5.6.6 und früher wurde das Cookie unter dem
+            // falschen Namen 'consent_manager' geschrieben. Wenn es noch existiert,
+            // einmalig nach 'consentmanager' umkopieren und das Alt-Cookie expiren —
+            // so muss der User nach dem Update nicht erneut zustimmen.
+            var legacy = this.getCookie('consent_manager');
+            if (legacy !== null) {
+                try {
+                    var expires = new Date();
+                    expires.setTime(expires.getTime() + (365 * 24 * 60 * 60 * 1000));
+                    document.cookie = 'consentmanager=' + legacy +
+                                     '; expires=' + expires.toUTCString() +
+                                     '; path=/; SameSite=Lax';
+                    document.cookie = 'consent_manager=; expires=' + new Date(0).toUTCString() + '; path=/';
+                } catch(e) { /* ignore */ }
+                return legacy;
+            }
+            return null;
         },
         
         getCookie: function(name) {

--- a/fragments/ConsentManager/inline_placeholder.php
+++ b/fragments/ConsentManager/inline_placeholder.php
@@ -24,6 +24,11 @@ $content = $this->getVar('content', '');
 $consentId = $this->getVar('consentId', uniqid('consent_', true));
 $serviceKey = $this->getVar('serviceKey', '');
 
+// Optionale CSS-Klasse (laut docs/inline.md unterstützt) an den Container hängen
+$extraClass = (isset($options['css_class']) && is_string($options['css_class']) && '' !== $options['css_class'])
+    ? ' ' . rex_escape($options['css_class'])
+    : '';
+
 // Text-Variablen aus Fragment abrufen (von FriendsOfRedaxo\ConsentManager\InlineConsent::getButtonText())
 $inline_title_fallback = $this->getVar('inline_title_fallback', 'Externes Medium');
 $inline_privacy_notice = $this->getVar('inline_privacy_notice', 'Für die Anzeige werden Cookies benötigt.');
@@ -57,7 +62,7 @@ if ('' !== $thumbnailSrc) {
 }
 ?>
 
-<div class="consent-inline-container" data-consent-id="<?= rex_escape($consentId) ?>" 
+<div class="consent-inline-container<?= $extraClass ?>" data-consent-id="<?= rex_escape($consentId) ?>"
      data-service="<?= rex_escape($serviceKey) ?>">
     
     <div class="consent-inline-placeholder">

--- a/fragments/ConsentManager/inline_placeholder.php
+++ b/fragments/ConsentManager/inline_placeholder.php
@@ -21,7 +21,13 @@ $service = $this->getVar('service', []);
 $options = $this->getVar('options', []);
 $placeholderData = $this->getVar('placeholderData', []);
 $content = $this->getVar('content', '');
-$consentId = $this->getVar('consentId', uniqid('consent_', true));
+// Erst Var holen, Fallback nur bei Bedarf erzeugen — uniqid() würde sonst
+// auch bei gesetzter ID auf jedem Render-Pfad ausgewertet (PHP wertet
+// Default-Argumente eager aus).
+$consentId = $this->getVar('consentId', '');
+if ('' === $consentId) {
+    $consentId = uniqid('consent_', true);
+}
 $serviceKey = $this->getVar('serviceKey', '');
 
 // Optionale CSS-Klasse (laut docs/inline.md unterstützt) an den Container hängen

--- a/fragments/ConsentManager/inline_placeholder.php
+++ b/fragments/ConsentManager/inline_placeholder.php
@@ -21,6 +21,8 @@ $service = $this->getVar('service', []);
 $options = $this->getVar('options', []);
 $placeholderData = $this->getVar('placeholderData', []);
 $content = $this->getVar('content', '');
+$consentId = $this->getVar('consentId', uniqid('consent_', true));
+$serviceKey = $this->getVar('serviceKey', '');
 
 // Text-Variablen aus Fragment abrufen (von FriendsOfRedaxo\ConsentManager\InlineConsent::getButtonText())
 $inline_title_fallback = $this->getVar('inline_title_fallback', 'Externes Medium');


### PR DESCRIPTION
This PR fixes four issues I hit when integrating the inline consent flow
in a customer project on REDAXO 5.20.

Each commit is independent and can be cherry-picked.

### 1. `inline_placeholder.php` — `$consentId` / `$serviceKey` never initialized

`InlineConsent::renderPlaceholderHTML()` passes both via `$fragment->setVar()`
but the template only retrieves `$service`, `$options`, `$placeholderData`
and `$content` via `$this->getVar()`. `$consentId` and `$serviceKey` are
used as bare variables (lines 58, 105 etc.) — REDAXO `rex_fragment`
doesn't `extract()` set vars, so both are `null`. With `display_errors`
on this produces PHP warnings inside the `data-consent-id` attribute,
which breaks the JS that reads that attribute.

### 2. `consent_inline.js` cookie name mismatch

`setCookieData()` writes the cookie as `consent_manager=…` (with
underscore). All read paths (`getStorageValue`, `getCookie('…')`,
`sessionStorage.getItem`) use `consentmanager` (no underscore).
Result: the consent cookie is set but never found again after reload —
the inline placeholder reappears every page load even when the user
already accepted.

This commit fixes the write name and also cleans up the old
underscore cookie so users who already hit the bug don't end up with
two stale cookies.

### 3. Documented `css_class` option is not implemented

`docs/inline.md` lists `'css_class'` as a supported option (line 504,
565, 569, 741, with an example `'consent-theme-minimal'`) but
`grep -r css_class lib/ fragments/` returns no hits. The option is
silently dropped.

This commit appends the option value as an extra class on the outer
`.consent-inline-container` element so users can theme individual
placeholders the way the docs already promise.

### 4. Default `--consent-overlay-max-width: 90%` makes the overlay not cover the placeholder

The placeholder defines `--consent-overlay-max-width: 90%` (95% on
mobile) on `.consent-inline-placeholder`, and `.consent-inline-overlay`
consumes it as `max-width: var(--consent-overlay-max-width)`. In a
wrapping container with a locked aspect-ratio (e.g. a 16:9 video box),
the overlay stays 10% narrower than the thumbnail behind it — the
thumbnail peeks out at the sides and the placeholder looks broken.

There is no backend setting or `theme_editor` field for this. Overriding
the variable from a wrapper element doesn't work because the var is
re-declared on the placeholder (a descendant), so the wrapper-level
value never reaches the overlay.

This commit sets the default to `100%`. Users who want inset spacing
can use the existing `--consent-overlay-padding` variable instead.

---

Tested against v5.6.6 in a live customer project. Happy to split into
separate PRs if you'd prefer.