### PR TITLE
Fix IDN-Domain handling with user-friendly umlaut input/output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # REDAXO consent_manager - Changelog
 
+## Version 5.6.9 - 02.07.2026
+
+- **Fix (IDN/Umlaut-Domains):** Domain-Eingaben wie `müller.de` werden nun durchgängig akzeptiert und intern robust gegen UTF-8-/Punycode-Varianten aufgelöst.
+- **Fix (Frontend/Auto-Inject/Debug):** Domain-Matching nutzt jetzt Variantenauflösung, sodass Konfigurationen auch dann greifen, wenn Request-Host und gespeicherte Domain in unterschiedlicher Schreibweise (Umlaut vs. `xn--...`) vorliegen.
+- **UX (Backend):** Domain-Hinweise in der Verwaltung präzisiert; Umlaut-Domains können direkt in der korrekten Schreibweise eingegeben werden.
+
 ## Version 5.6.8 - 02.07.2026
 - **Fix Import einer json Settings Datei funktioniert jetzt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # REDAXO consent_manager - Changelog
 
+## Version 5.6.10 - 05.07.2026
+
+- **Fix (IDN/Domain-Matching):** Domain-Abgleich wurde über Variantenauflösung stabilisiert (UTF-8/Punycode), damit gespeicherte und angefragte Hosts zuverlässig zusammenfinden.
+- **Fix (Backend-Validierung):** Hostname-Validierung akzeptiert nur noch echte Hostnamen und weist URLs mit Protokoll, Pfad, Query, Fragment oder Userinfo konsequent ab.
+- **Fix (Domain-Setup):** Domain-Bereinigung im Setup-Wizard nutzt dieselbe Normalisierungslogik wie der Rest des Addons und speichert konsistente Domainwerte.
+- **UX (Backend):** Domain-Hinweistext aktualisiert: Umlaut-Domains koennen direkt eingegeben werden; interne Punycode-Umwandlung wird transparent kommuniziert.
+
 ## Version 5.6.9 - 02.07.2026
 
 - **Fix (IDN/Umlaut-Domains):** Domain-Eingaben wie `müller.de` werden nun durchgängig akzeptiert und intern robust gegen UTF-8-/Punycode-Varianten aufgelöst.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **Fix (IDN/Domain-Matching):** Domain-Abgleich wurde über Variantenauflösung stabilisiert (UTF-8/Punycode), damit gespeicherte und angefragte Hosts zuverlässig zusammenfinden.
 - **Fix (Backend-Validierung):** Hostname-Validierung akzeptiert nur noch echte Hostnamen und weist URLs mit Protokoll, Pfad, Query, Fragment oder Userinfo konsequent ab.
 - **Fix (Domain-Setup):** Domain-Bereinigung im Setup-Wizard nutzt dieselbe Normalisierungslogik wie der Rest des Addons und speichert konsistente Domainwerte.
+- **Fix (Cookie-Migration/Cleanup):** Serverseitiges Löschen alter Consent-Cookies nutzt jetzt normalisierte Domain-Varianten (inkl. host-only und Punkt-Präfix), damit Bereinigung auch bei IDN/Host-Edge-Cases zuverlässig greift.
+- **Fix (Backend/YRewrite):** YRewrite-Domainauswahl verwendet die zentrale Variantenauflösung für UTF-8/Punycode und vermeidet dadurch inkonsistente Duplikate.
 - **UX (Backend):** Domain-Hinweistext aktualisiert: Umlaut-Domains koennen direkt eingegeben werden; interne Punycode-Umwandlung wird transparent kommuniziert.
 
 ## Version 5.6.9 - 02.07.2026

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Der Consent Manager bietet eine DSGVO-konforme Lösung für die Einholung und Ve
 - Flexible Gruppierung von Diensten
 - Nachträgliche Änderung der Einstellungen durch Besucher
 - Mehrsprachig und Multi-Domain-fähig
+- IDN-/Umlaut-Domains werden robust unterstützt (UTF-8/Punycode)
 - Automatische Frontend-Einbindung (Auto-Inject)
 - Inline-Consent für Embeds (YouTube, Vimeo, Maps etc.)
 - Google Consent Mode v2

--- a/boot.php
+++ b/boot.php
@@ -184,12 +184,21 @@ if (rex::isFrontend()) {
 
         // delete server-side (works also for HttpOnly cookies)
         if ($mustDelete) {
-            $host = $_SERVER['HTTP_HOST'] ?? '';
+            $host = Utility::normalizeDomain((string) rex_request::server('HTTP_HOST', 'string', ''));
             $secure = (!empty($_SERVER['HTTPS']) && 'off' !== $_SERVER['HTTPS']);
-            // expire for current host/path
-            setcookie($cookieName, '', time() - 3600, '/', $host, $secure, true);
-            // also try shorter flags (some older cookies may differ)
-            setcookie($cookieName, '', time() - 3600, '/', $host, $secure, false);
+
+            // Expire host-only cookie and explicit domain variants for robust cleanup.
+            $cookieDomains = [''];
+            if ('' !== $host) {
+                $cookieDomains[] = $host;
+                $cookieDomains[] = '.' . ltrim($host, '.');
+            }
+
+            foreach (array_unique($cookieDomains) as $cookieDomain) {
+                // expire for current host/path (HttpOnly + non-HttpOnly legacy variant)
+                setcookie($cookieName, '', time() - 3600, '/', $cookieDomain, $secure, true);
+                setcookie($cookieName, '', time() - 3600, '/', $cookieDomain, $secure, false);
+            }
         }
 
         // set sentinel to avoid repeating this check for this visitor

--- a/boot.php
+++ b/boot.php
@@ -233,7 +233,7 @@ if (rex::isFrontend()) {
 
         $sql = rex_sql::factory();
         $sql->setQuery(
-            'SELECT auto_inject, auto_inject_reload_on_consent, auto_inject_delay, auto_inject_focus, auto_inject_include_templates 
+            'SELECT uid, auto_inject, auto_inject_reload_on_consent, auto_inject_delay, auto_inject_focus, auto_inject_include_templates 
              FROM ' . rex::getTable('consent_manager_domain') . ' 
              WHERE uid IN (' . $inPlaceholders . ')
              ORDER BY FIELD(uid, ' . $orderPlaceholders . ')

--- a/boot.php
+++ b/boot.php
@@ -11,6 +11,7 @@ use FriendsOfRedaxo\ConsentManager\GoogleConsentMode;
 use FriendsOfRedaxo\ConsentManager\InlineConsent;
 use FriendsOfRedaxo\ConsentManager\OEmbedParser;
 use FriendsOfRedaxo\ConsentManager\RexFormSupport;
+use FriendsOfRedaxo\ConsentManager\Utility;
 
 $addon = rex_addon::get('consent_manager');
 
@@ -221,24 +222,31 @@ if (rex::isFrontend()) {
 
         // Domain-Konfiguration prüfen
         $domain = rex_request::server('HTTP_HOST', 'string', '');
-        if ('' === $domain) {
+        $domainCandidates = Utility::getDomainVariants($domain);
+        if ([] === $domainCandidates) {
             return $content;
         }
 
-        $domain = strtolower($domain);
+        $inPlaceholders = implode(', ', array_fill(0, count($domainCandidates), '?'));
+        $orderPlaceholders = implode(', ', array_fill(0, count($domainCandidates), '?'));
+        $domainParams = array_merge($domainCandidates, $domainCandidates);
 
         $sql = rex_sql::factory();
         $sql->setQuery(
             'SELECT auto_inject, auto_inject_reload_on_consent, auto_inject_delay, auto_inject_focus, auto_inject_include_templates 
              FROM ' . rex::getTable('consent_manager_domain') . ' 
-             WHERE uid = ?',
-            [$domain],
+             WHERE uid IN (' . $inPlaceholders . ')
+             ORDER BY FIELD(uid, ' . $orderPlaceholders . ')
+             LIMIT 1',
+            $domainParams,
         );
 
         // Nur einbinden wenn explizit aktiviert
         if (0 === $sql->getRows() || 1 !== (int) $sql->getValue('auto_inject')) {
             return $content;
         }
+
+        $domain = (string) $sql->getValue('uid');
 
         // Template-Whitelist prüfen (Positivliste)
         $includeTemplates = $sql->getValue('auto_inject_include_templates');
@@ -309,16 +317,27 @@ if (rex::isFrontend()) {
 
         // Domain-Konfiguration prüfen
         $domain = rex_request::server('HTTP_HOST', 'string', '');
-        $domain = strtolower($domain);
+        $domainCandidates = Utility::getDomainVariants($domain);
+        if ([] === $domainCandidates) {
+            return;
+        }
+
+        $inPlaceholders = implode(', ', array_fill(0, count($domainCandidates), '?'));
+        $orderPlaceholders = implode(', ', array_fill(0, count($domainCandidates), '?'));
+        $domainParams = array_merge($domainCandidates, $domainCandidates);
 
         $sql = rex_sql::factory();
         $sql->setQuery(
-            'SELECT google_consent_mode_debug FROM ' . rex::getTable('consent_manager_domain') . ' WHERE uid = ?',
-            [$domain],
+            'SELECT uid, google_consent_mode_debug FROM ' . rex::getTable('consent_manager_domain') . ' 
+             WHERE uid IN (' . $inPlaceholders . ')
+             ORDER BY FIELD(uid, ' . $orderPlaceholders . ')
+             LIMIT 1',
+            $domainParams,
         );
 
         $debugEnabled = false;
         if ($sql->getRows() > 0) {
+            $domain = (string) $sql->getValue('uid');
             $debugEnabled = (bool) $sql->getValue('google_consent_mode_debug');
         }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -129,6 +129,22 @@ if (!Utility::consentConfigured()) {
 - `hostname()`: liefert den aktuellen Host inkl. Subdomain (domain-spezifischer Consent)
 - `get_domaininfo($url)`: zerlegt eine URL in Domain-Bestandteile
 
+#### Domain-Normalisierung und Variantenaufloesung
+
+- `normalizeDomain($domain)`: normalisiert auf ASCII/Punycode zur konsistenten Verarbeitung
+- `getDomainVariants($domain)`: liefert robuste Kandidaten fuer Matching (UTF-8 + Punycode)
+- `resolveConfiguredDomainKey($domains, $domain)`: loest einen Request-Host auf den tatsaechlich konfigurierten Domain-Key auf
+
+Beispiel:
+
+```php
+$variants = Utility::getDomainVariants('müller.de');
+// z. B. ['müller.de', 'xn--mller-kva.de']
+
+$domains = ConsentManager::getDomains();
+$resolved = Utility::resolveConfiguredDomainKey($domains, 'xn--mller-kva.de');
+```
+
 ### ConsentManager
 
 Statischer Zugriff auf den aufgebauten Addon-Cache.

--- a/docs/installation_und_grundeinrichtung.md
+++ b/docs/installation_und_grundeinrichtung.md
@@ -13,6 +13,8 @@ Der Setup Wizard führt durch die Erstkonfiguration und übernimmt die wichtigst
 ### 1) Domain wählen
 
 - Domain kann manuell eingetragen werden.
+- Umlaut-Domains koennen direkt eingegeben werden (z. B. `müller.de`).
+- Intern werden Domain-Varianten (UTF-8/Punycode) fuer Matching und Duplikat-Pruefung aufgeloest.
 - Falls `yrewrite` aktiv ist, werden verfügbare Domains zur Auswahl angeboten.
 - Bereits konfigurierte Domains werden nicht erneut als Vorschlag angezeigt.
 
@@ -91,6 +93,7 @@ Vorteil: Die Consent-Box integriert sich visuell in das bestehende Frontend ohne
 Backend: `Consent Manager → Domains → Domain hinzufügen`
 
 - Domain ohne Protokoll eintragen (z. B. `beispiel.de`)
+- Keine URL-Bestandteile eingeben (kein Pfad, Query, Fragment oder Userinfo)
 - Datenschutz/Impressum zuweisen
 - Auto-Inject aktivieren (empfohlen)
 

--- a/lib/Api/ConsentManager.php
+++ b/lib/Api/ConsentManager.php
@@ -2,6 +2,7 @@
 
 namespace FriendsOfRedaxo\ConsentManager\Api;
 
+use FriendsOfRedaxo\ConsentManager\Utility;
 use rex;
 use rex_api_function;
 use rex_request;
@@ -32,12 +33,14 @@ class ConsentManager extends rex_api_function
             exit;
         }
 
+        $normalizedDomain = Utility::normalizeDomain($domain);
+
         // Security: Validate domain format (basic hostname validation)
         // Only allow valid hostname characters and limit length (DNS max = 255)
-        if (strlen($domain) > 255) {
+        if ('' === $normalizedDomain || strlen($normalizedDomain) > 255) {
             exit;
         }
-        if (!preg_match('/^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$/', $domain) && !preg_match('/^[a-zA-Z0-9]$/', $domain)) {
+        if (false === filter_var($normalizedDomain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {
             exit;
         }
 
@@ -98,7 +101,7 @@ class ConsentManager extends rex_api_function
             $db = rex_sql::factory();
             $db->setTable(rex::getTable('consent_manager_consent_log'));
             // Domain in Kleinbuchstaben normalisieren beim Speichern ins Log
-            $db->setValue('domain', strtolower($domain));
+            $db->setValue('domain', $normalizedDomain);
             $db->setValue('consentid', $consentid);
             // Use validated consents only (prevents XSS via malicious consent values)
             $db->setValue('consents', json_encode($validatedConsents));

--- a/lib/Api/consent_manager_setup_wizard.php
+++ b/lib/Api/consent_manager_setup_wizard.php
@@ -162,9 +162,9 @@ class rex_api_consent_manager_setup_wizard extends rex_api_function
             $domain = substr($domain, 0, $pos);
         }
 
-            $variants = Utility::getDomainVariants($domain);
+        $variants = Utility::getDomainVariants($domain);
 
-            return $variants[0] ?? '';
+        return $variants[0] ?? '';
     }
 
     /**

--- a/lib/Api/consent_manager_setup_wizard.php
+++ b/lib/Api/consent_manager_setup_wizard.php
@@ -7,6 +7,7 @@
 
 use FriendsOfRedaxo\ConsentManager\Cache;
 use FriendsOfRedaxo\ConsentManager\JsonSetup;
+use FriendsOfRedaxo\ConsentManager\Utility;
 
 class rex_api_consent_manager_setup_wizard extends rex_api_function
 {
@@ -161,10 +162,9 @@ class rex_api_consent_manager_setup_wizard extends rex_api_function
             $domain = substr($domain, 0, $pos);
         }
 
-        // Zu lowercase
-        $domain = strtolower($domain);
+            $variants = Utility::getDomainVariants($domain);
 
-        return $domain;
+            return $variants[0] ?? '';
     }
 
     /**

--- a/lib/ConsentManager.php
+++ b/lib/ConsentManager.php
@@ -74,7 +74,21 @@ class ConsentManager
     public static function getDomain(string $domain): ?array
     {
         self::initCache();
-        return self::$cache['domains'][$domain] ?? null;
+        if (isset(self::$cache['domains'][$domain])) {
+            return self::$cache['domains'][$domain];
+        }
+
+        $domains = self::$cache['domains'] ?? [];
+        if (!is_array($domains) || [] === $domains) {
+            return null;
+        }
+
+        $resolvedKey = Utility::resolveConfiguredDomainKey($domains, $domain);
+        if ('' !== $resolvedKey && isset($domains[$resolvedKey]) && is_array($domains[$resolvedKey])) {
+            return $domains[$resolvedKey];
+        }
+
+        return null;
     }
 
     /**

--- a/lib/Frontend.php
+++ b/lib/Frontend.php
@@ -109,30 +109,22 @@ class Frontend
      */
     public function setDomain(string $domain)
     {
-        // Domain immer in Kleinbuchstaben normalisieren für den Lookup
-        $domain = Utility::hostname();
-
         $domains = ConsentManager::getDomains();
         if (empty($domains)) {
             return;
         }
 
-        // Zuerst exakte Domain suchen
-        if (isset($domains[$domain])) {
-            $this->domainName = $domain;
-        } else {
-            // Dann HTTP_HOST versuchen (für Fälle mit Port oder Subdomain)
-            $httpHost = strtolower(rex_request::server('HTTP_HOST'));
-            if (isset($domains[$httpHost])) {
-                $this->domainName = $httpHost;
-            } else {
-                // Domain ohne Port versuchen
-                $httpHostNoPort = preg_replace('/:\d+$/', '', $httpHost);
-                if (isset($domains[$httpHostNoPort])) {
-                    $this->domainName = $httpHostNoPort;
-                } else {
-                    return;
-                }
+        $domainCandidates = [
+            $domain,
+            Utility::hostname(),
+            (string) rex_request::server('HTTP_HOST'),
+        ];
+
+        foreach ($domainCandidates as $candidate) {
+            $resolved = Utility::resolveConfiguredDomainKey($domains, $candidate);
+            if ('' !== $resolved) {
+                $this->domainName = $resolved;
+                break;
             }
         }
 

--- a/lib/GoogleConsentMode.php
+++ b/lib/GoogleConsentMode.php
@@ -66,10 +66,10 @@ class GoogleConsentMode
      */
     public static function getDomainConfig(string $domain): array
     {
-        // Domain in Kleinbuchstaben normalisieren für den Lookup
-        $domain = strtolower($domain);
+        $resolvedDomain = Utility::resolveConfiguredDomainKey(ConsentManager::getDomains(), $domain);
+        $lookupDomain = '' !== $resolvedDomain ? $resolvedDomain : strtolower($domain);
 
-        $domainData = ConsentManager::getDomain($domain);
+        $domainData = ConsentManager::getDomain($lookupDomain);
         $mode = 'disabled';
 
         if (is_array($domainData) && count($domainData) > 0) {
@@ -81,7 +81,7 @@ class GoogleConsentMode
             'auto_mapping' => 'auto' === $mode,
             'mode' => $mode,
             'default_state' => 'denied', // GDPR-konform immer denied als Default
-            'domain' => $domain,
+            'domain' => $lookupDomain,
             'flags' => self::$defaultConsentFlags,
         ];
     }

--- a/lib/OEmbedParser.php
+++ b/lib/OEmbedParser.php
@@ -223,14 +223,23 @@ class OEmbedParser
             return $defaultConfig;
         }
 
+        $domainVariants = Utility::getDomainVariants($domain);
+        if ([] === $domainVariants) {
+            return $defaultConfig;
+        }
+
         try {
             $sql = rex_sql::factory();
-            // TODO: Query ändern in setTable/setWhere/select
+            $placeholders = implode(', ', array_fill(0, count($domainVariants), '?'));
+            $orderPlaceholders = implode(', ', array_fill(0, count($domainVariants), '?'));
+
             $sql->setQuery('
                 SELECT oembed_enabled, oembed_video_width, oembed_video_height, oembed_show_allow_all
                 FROM ' . rex::getTable('consent_manager_domain') . '
-                WHERE uid = ?
-            ', [$domain]);
+                WHERE uid IN (' . $placeholders . ')
+                ORDER BY FIELD(uid, ' . $orderPlaceholders . ')
+                LIMIT 1
+            ', array_merge($domainVariants, $domainVariants));
 
             if ($sql->getRows() > 0) {
                 $dbConfig = [
@@ -250,8 +259,9 @@ class OEmbedParser
         $addon = rex_addon::get('consent_manager');
         $domainConfigs = $addon->getProperty('oembed_domain_configs', []);
 
-        if (isset($domainConfigs[$domain])) {
-            return array_merge($defaultConfig, $domainConfigs[$domain]);
+        $resolvedDomain = Utility::resolveConfiguredDomainKey(is_array($domainConfigs) ? $domainConfigs : [], $domain);
+        if ('' !== $resolvedDomain && isset($domainConfigs[$resolvedDomain])) {
+            return array_merge($defaultConfig, $domainConfigs[$resolvedDomain]);
         }
 
         return $defaultConfig;

--- a/lib/RexFormSupport.php
+++ b/lib/RexFormSupport.php
@@ -504,8 +504,8 @@ class RexFormSupport
     public static function validateHostname(string $hostname): bool|string
     {
         $trimmed = trim($hostname);
-        // Reject input that contains a protocol, path, query string, fragment, or userinfo –
-        // only a plain hostname (with optional port) is acceptable.
+        // Reject input that contains a protocol, path, query string, fragment, or userinfo.
+        // Only a plain hostname is acceptable (e.g. "example.com" or "müller.de").
         if (
             false !== strpos($trimmed, '://') ||
             false !== strpos($trimmed, '/') ||

--- a/lib/RexFormSupport.php
+++ b/lib/RexFormSupport.php
@@ -503,9 +503,9 @@ class RexFormSupport
      */
     public static function validateHostname(string $hostname): bool|string
     {
-        $host = parse_url('https://' . $hostname);
-        if (isset($host['scheme']) && isset($host['host']) && !isset($host['path'])) {
-            return filter_var($host['host'], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+        $normalizedHost = Utility::normalizeDomain($hostname);
+        if ('' !== $normalizedHost) {
+            return filter_var($normalizedHost, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
         }
         return false;
     }

--- a/lib/RexFormSupport.php
+++ b/lib/RexFormSupport.php
@@ -503,7 +503,19 @@ class RexFormSupport
      */
     public static function validateHostname(string $hostname): bool|string
     {
-        $normalizedHost = Utility::normalizeDomain($hostname);
+        $trimmed = trim($hostname);
+        // Reject input that contains a protocol, path, query string, fragment, or userinfo –
+        // only a plain hostname (with optional port) is acceptable.
+        if (
+            false !== strpos($trimmed, '://') ||
+            false !== strpos($trimmed, '/') ||
+            false !== strpos($trimmed, '?') ||
+            false !== strpos($trimmed, '#') ||
+            false !== strpos($trimmed, '@')
+        ) {
+            return false;
+        }
+        $normalizedHost = Utility::normalizeDomain($trimmed);
         if ('' !== $normalizedHost) {
             return filter_var($normalizedHost, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
         }

--- a/lib/Utility.php
+++ b/lib/Utility.php
@@ -8,9 +8,14 @@ use rex_request;
 use rex_sql;
 
 use function count;
+use function function_exists;
+use function implode;
 use function is_array;
 use function is_string;
+use function parse_url;
+use function strtolower;
 use function strlen;
+use function trim;
 
 class Utility
 {
@@ -44,12 +49,19 @@ class Utility
         $db = rex_sql::factory();
         $db->setDebug(false);
 
-        // Check host
-        // TODO: setTable/setWhere/select
-        $db->prepareQuery('SELECT `id` FROM `' . rex::getTable('consent_manager_domain') . '` WHERE `uid` = :uid');
-        $dbresult = $db->execute(['uid' => rex_request::server('HTTP_HOST')]);
-        if (1 === $dbresult->getRows()) {
-            $domain = $dbresult->getValue('id');
+        $hostVariants = self::getDomainVariants((string) rex_request::server('HTTP_HOST'));
+        if ([] === $hostVariants) {
+            return false;
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($hostVariants), '?'));
+        $db->setQuery(
+            'SELECT `id` FROM `' . rex::getTable('consent_manager_domain') . '` WHERE `uid` IN (' . $placeholders . ') LIMIT 1',
+            $hostVariants,
+        );
+
+        if (1 === $db->getRows()) {
+            $domain = $db->getValue('id');
             // Check domain in cookie group
             $db->prepareQuery('SELECT count(*) as `count` FROM `' . rex::getTable('consent_manager_cookiegroup') . '` WHERE `domain` LIKE :domain AND `clang_id` = :clang AND `cookie` != \'\'');
             $dbresult = $db->execute(['domain' => '%|' . $domain . '|%', 'clang' => rex_clang::getCurrentId()]);
@@ -69,12 +81,93 @@ class Utility
      */
     public static function hostname(): string
     {
-        $dominfo = self::get_domaininfo('https://' . rex_request::server('HTTP_HOST'));
-        // Return full hostname including subdomain (DSGVO requirement)
-        if ('' < $dominfo['subdomain']) {
-            return strtolower($dominfo['subdomain'] . '.' . $dominfo['domain']);
+        return self::extractHost((string) rex_request::server('HTTP_HOST'));
+    }
+
+    /**
+     * Normalize domain to ASCII (punycode) when possible.
+     *
+     * @api
+     */
+    public static function normalizeDomain(string $domain): string
+    {
+        $host = self::extractHost($domain);
+        if ('' === $host) {
+            return '';
         }
-        return strtolower($dominfo['domain']);
+
+        if (function_exists('idn_to_ascii')) {
+            $idnaOptions = defined('IDNA_DEFAULT') ? IDNA_DEFAULT : 0;
+            $ascii = idn_to_ascii($host, $idnaOptions);
+            if (is_string($ascii) && '' !== $ascii) {
+                return self::toLower($ascii);
+            }
+        }
+
+        return $host;
+    }
+
+    /**
+     * Returns UTF-8 and ASCII domain variants for robust matching.
+     *
+     * @api
+     * @return array<int, string>
+     */
+    public static function getDomainVariants(string $domain): array
+    {
+        $host = self::extractHost($domain);
+        if ('' === $host) {
+            return [];
+        }
+
+        $variants = [$host];
+
+        $ascii = self::normalizeDomain($host);
+        if ('' !== $ascii) {
+            $variants[] = $ascii;
+        }
+
+        if (function_exists('idn_to_utf8')) {
+            $idnaOptions = defined('IDNA_DEFAULT') ? IDNA_DEFAULT : 0;
+            $utf8FromHost = idn_to_utf8($host, $idnaOptions);
+            if (is_string($utf8FromHost) && '' !== $utf8FromHost) {
+                $variants[] = self::toLower($utf8FromHost);
+            }
+
+            if ('' !== $ascii) {
+                $utf8FromAscii = idn_to_utf8($ascii, $idnaOptions);
+                if (is_string($utf8FromAscii) && '' !== $utf8FromAscii) {
+                    $variants[] = self::toLower($utf8FromAscii);
+                }
+            }
+        }
+
+        return array_values(array_unique(array_filter($variants, static fn ($value) => is_string($value) && '' !== $value)));
+    }
+
+    /**
+     * Resolve configured domain key from UTF-8/punycode candidates.
+     *
+     * @param array<string, mixed> $domains
+     *
+     * @api
+     */
+    public static function resolveConfiguredDomainKey(array $domains, string $domain): string
+    {
+        foreach (self::getDomainVariants($domain) as $candidate) {
+            if (isset($domains[$candidate])) {
+                return $candidate;
+            }
+        }
+
+        $normalizedCandidates = array_unique(array_map([self::class, 'normalizeDomain'], self::getDomainVariants($domain)));
+        foreach (array_keys($domains) as $configuredDomain) {
+            if (in_array(self::normalizeDomain((string) $configuredDomain), $normalizedCandidates, true)) {
+                return (string) $configuredDomain;
+            }
+        }
+
+        return '';
     }
 
     /**
@@ -111,5 +204,33 @@ class Utility
             'host' => strtolower($host),     // Host auch in Kleinbuchstaben
             'tld' => strtolower($tld),       // TLD auch in Kleinbuchstaben
         ];
+    }
+
+    private static function extractHost(string $domain): string
+    {
+        $value = trim($domain);
+        if ('' === $value) {
+            return '';
+        }
+
+        if (false === strpos($value, '://')) {
+            $value = 'https://' . $value;
+        }
+
+        $host = (string) parse_url($value, PHP_URL_HOST);
+        if ('' === $host) {
+            return '';
+        }
+
+        return self::toLower(trim($host, '.'));
+    }
+
+    private static function toLower(string $value): string
+    {
+        if (function_exists('mb_strtolower')) {
+            return mb_strtolower($value, 'UTF-8');
+        }
+
+        return strtolower($value);
     }
 }

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: consent_manager
-version: "5.6.8"
+version: "5.6.9"
 author: "Friends Of REDAXO"
 supportpage: https://redaxo.org/support/community/#slack
 

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: consent_manager
-version: "5.6.9"
+version: "5.6.10"
 author: "Friends Of REDAXO"
 supportpage: https://redaxo.org/support/community/#slack
 

--- a/pages/domain.php
+++ b/pages/domain.php
@@ -2,6 +2,7 @@
 
 use FriendsOfRedaxo\ConsentManager\RexFormSupport;
 use FriendsOfRedaxo\ConsentManager\Theme;
+use FriendsOfRedaxo\ConsentManager\Utility;
 
 $showlist = true;
 $id = rex_request::request('id', 'int', 0);
@@ -36,26 +37,35 @@ if ('delete' === $func) {
 
     // YRewrite Domains laden falls verfügbar
     $yrewriteDomains = [];
+    $yrewriteDomainSet = [];
     $existingDomains = [];
+    $existingDomainSet = [];
 
     // Bereits konfigurierte Domains laden (außer der aktuellen beim Edit)
     $sql = rex_sql::factory();
     $whereClause = $form->isEditMode() ? 'id != ' . $id : '1=1';
     $sql->setQuery('SELECT uid FROM ' . rex::getTable('consent_manager_domain') . ' WHERE ' . $whereClause);
     foreach ($sql as $row) {
-        $existingDomains[] = $row->getValue('uid');
+        $uid = (string) $row->getValue('uid');
+        $existingDomains[] = $uid;
+        foreach (Utility::getDomainVariants($uid) as $variant) {
+            $existingDomainSet[$variant] = true;
+        }
     }
 
     $yrewriteSelectHtml = '';
     if (rex_addon::exists('yrewrite') && rex_addon::get('yrewrite')->isAvailable()) {
         foreach (rex_yrewrite::getDomains() as $domain) {
-            $cleanDomain = preg_replace('#^https?://#i', '', $domain->getUrl());
-            $cleanDomain = rtrim($cleanDomain, '/');
-            $cleanDomain = strtolower($cleanDomain);
+            $variants = Utility::getDomainVariants((string) $domain->getUrl());
+            $cleanDomain = $variants[0] ?? '';
+            if ('' === $cleanDomain) {
+                continue;
+            }
 
             // Duplikate vermeiden (z.B. wenn eine Domain sowohl als Standard als auch regulär existiert)
-            if (!in_array($cleanDomain, $yrewriteDomains, true) && !in_array($cleanDomain, $existingDomains, true)) {
+            if (!isset($yrewriteDomainSet[$cleanDomain]) && !isset($existingDomainSet[$cleanDomain])) {
                 $yrewriteDomains[] = $cleanDomain;
+                $yrewriteDomainSet[$cleanDomain] = true;
             }
         }
 

--- a/pages/domain.php
+++ b/pages/domain.php
@@ -112,7 +112,7 @@ if ('delete' === $func) {
     $field->setLabel(count($yrewriteDomains) > 0 && !$form->isEditMode() ? '<small class="text-muted">Oder eigene Domain eingeben:</small>' : rex_i18n::msg('consent_manager_domain'));
     $field->getValidator()->add('notEmpty', rex_i18n::msg('consent_manager_domain_empty_msg'));
     $field->getValidator()->add('custom', rex_i18n::msg('consent_manager_domain_malformed_msg'), RexFormSupport::validateHostname(...));
-    $field->setNotice('Domain ohne Protokoll eingeben (z.B. "example.com" oder "müller.de"). Umlaut-Domains werden intern automatisch in Punycode umgewandelt, sofern die PHP-Erweiterung "intl" verfügbar ist. Ohne "intl" müssen Umlaut-Domains manuell in Punycode (z.B. "xn--mller-kva.de") eingegeben werden.');
+    $field->setNotice('Domain ohne Protokoll eingeben (z.B. "example.com" oder "müller.de"). Umlaut-Domains werden intern automatisch in Punycode umgewandelt (z.B. "xn--mller-kva.de").');
     $field->setAttribute('id', 'domain-uid-field');
 
     $domainPanelEnd = '

--- a/pages/domain.php
+++ b/pages/domain.php
@@ -112,7 +112,7 @@ if ('delete' === $func) {
     $field->setLabel(count($yrewriteDomains) > 0 && !$form->isEditMode() ? '<small class="text-muted">Oder eigene Domain eingeben:</small>' : rex_i18n::msg('consent_manager_domain'));
     $field->getValidator()->add('notEmpty', rex_i18n::msg('consent_manager_domain_empty_msg'));
     $field->getValidator()->add('custom', rex_i18n::msg('consent_manager_domain_malformed_msg'), RexFormSupport::validateHostname(...));
-    $field->setNotice('Domain ohne Protokoll eingeben (z.B. "example.com" oder "müller.de"). Umlaut-Domains werden intern automatisch kompatibel verarbeitet.');
+    $field->setNotice('Domain ohne Protokoll eingeben (z.B. "example.com" oder "müller.de"). Umlaut-Domains werden intern automatisch in Punycode umgewandelt, sofern die PHP-Erweiterung "intl" verfügbar ist. Ohne "intl" müssen Umlaut-Domains manuell in Punycode (z.B. "xn--mller-kva.de") eingegeben werden.');
     $field->setAttribute('id', 'domain-uid-field');
 
     $domainPanelEnd = '

--- a/pages/domain.php
+++ b/pages/domain.php
@@ -112,10 +112,7 @@ if ('delete' === $func) {
     $field->setLabel(count($yrewriteDomains) > 0 && !$form->isEditMode() ? '<small class="text-muted">Oder eigene Domain eingeben:</small>' : rex_i18n::msg('consent_manager_domain'));
     $field->getValidator()->add('notEmpty', rex_i18n::msg('consent_manager_domain_empty_msg'));
     $field->getValidator()->add('custom', rex_i18n::msg('consent_manager_domain_malformed_msg'), RexFormSupport::validateHostname(...));
-    $field->getValidator()->add('custom', 'Domain muss in Kleinbuchstaben eingegeben werden (z.B. "example.com" statt "Example.com")', static function ($value) {
-        return RexFormSupport::validateLowercase($value);
-    });
-    $field->setNotice('Domain ohne Protokoll eingeben (z.B. "example.com"). Bitte nur Kleinbuchstaben verwenden.');
+    $field->setNotice('Domain ohne Protokoll eingeben (z.B. "example.com" oder "müller.de"). Umlaut-Domains werden intern automatisch kompatibel verarbeitet.');
     $field->setAttribute('id', 'domain-uid-field');
 
     $domainPanelEnd = '


### PR DESCRIPTION
## Hintergrund
Issue #486 beschreibt Probleme mit Umlaut-Domains:
- UTF-8-Domain-Eingaben wurden in Teilen nicht sauber verarbeitet
- reine Punycode-Einträge konnten im Laufzeit-Matching zu "keine Texte/Domains/Dienste konfiguriert" führen

Diese Umsetzung ist **eine eigene Lösung auf separatem Branch** (nicht der Copilot-Branch #488).

## Ziel
- Nutzer geben Domains in korrekter Schreibweise ein (z. B. `müller.de`)
- intern wird für Matching/Validierung robust zwischen UTF-8 und Punycode aufgelöst
- Frontend/Backend zeigen weiterhin die korrekte Domain-Schreibweise

## Änderungen
- Zentrale IDN-Helfer in `Utility`:
  - `normalizeDomain()` (ASCII/punycode)
  - `getDomainVariants()` (UTF-8 + Punycode Varianten)
  - `resolveConfiguredDomainKey()` (auflösen auf tatsächlich konfigurierte Domain)
- Laufzeit-Matching aktualisiert:
  - `Frontend::setDomain()`
  - `Utility::consentConfigured()`
  - `boot.php` (Auto-Inject + Debug Domain-Lookup)
  - `ConsentManager::getDomain()` (cache-basierte Auflösung)
  - `OEmbedParser::getDomainConfig()`
  - `GoogleConsentMode::getDomainConfig()`
- Validierung/UX:
  - `RexFormSupport::validateHostname()` validiert strikt Hostnamen (keine URL-Bestandteile)
  - `pages/domain.php`: Hinweistext aktualisiert (IDN im Core vorausgesetzt)
  - `Api/ConsentManager.php`: API-Domainvalidierung IDN-fähig, Log speichert normalisierte Domain
  - Setup-Wizard Domainbereinigung auf Variantenauflösung umgestellt
- Zusätzliche Härtung in diesem PR:
  - Cookie-Migration/Cleanup löscht alte Cookies robuster über normalisierte Domain-Varianten (host-only + Punkt-Präfix)
  - YRewrite-Domainauswahl nutzt zentrale Variantenauflösung und vermeidet inkonsistente Duplikate
- Version/Changelog:
  - `package.yml` auf `5.6.10`
  - `CHANGELOG.md` ergänzt/erweitert

## Verifikation
- `php -l` auf geänderten PHP-Dateien: ohne Syntaxfehler
- Review-Threads wurden vollständig adressiert und resolved

Closes #486
