### PR TITLE
Google Consent Mode v2: consent-default synchron laden (defer entfernt)

### DIFF
--- a/fragments/ConsentManager/box_cssjs.php
+++ b/fragments/ConsentManager/box_cssjs.php
@@ -55,7 +55,11 @@ if (0 < count($consent_manager->domainInfo)
         $googleConsentModeScriptFile = 'google_consent_mode_v2.js';
     }
     $googleConsentModeScriptUrl = $addon->getAssetsUrl($googleConsentModeScriptFile);
-    $googleConsentModeOutput .= '    <script nonce="' . rex_response::getNonce() . '" src="' . $googleConsentModeScriptUrl . '" defer></script>' . PHP_EOL;
+    // Bewusst OHNE defer: der Consent-Default (gtag('consent','default', …)) muss SYNCHRON vor externen
+    // Tags (z.B. ein Google-Tag-Manager-Snippet im Template) im dataLayer stehen. Mit defer läuft dieses
+    // Script erst nach dem gtm.js-Event -> GTM wertet Tags mit "Additional consent required" (FB-Pixel,
+    // LinkedIn, TikTok …) mit denied aus und re-feuert sie nicht. Das Script ist klein und same-origin.
+    $googleConsentModeOutput .= '    <script nonce="' . rex_response::getNonce() . '" src="' . $googleConsentModeScriptUrl . '"></script>' . PHP_EOL;
 
     // Debug-Script laden wenn Debug-Modus aktiviert UND User im Backend eingeloggt
     if (isset($consent_manager->domainInfo['google_consent_mode_debug'])


### PR DESCRIPTION
Das google_consent_mode_v2-Script wird mit `defer` eingebunden. Dadurch laeuft es erst nach dem HTML-Parsing und pusht `gtag('consent','default', …)` erst spaet in den dataLayer.

Laedt eine Seite einen externen Tag im <head> -- typisch ein Google-Tag- Manager-Snippet, ueber das Agenturen ihre Marketing-Tags verwalten -- dann initialisiert GTM VOR diesem deferred Consent-Default. GTM wertet den Page-View also mit consent=denied aus. Googles eigene Tags (GA4) verzeihen das (eingebaute Wartelogik), aber jeder Nicht-Google-Tag mit "Additional consent required" (Facebook-Pixel, LinkedIn, TikTok, …) wird geblockt und NICHT nachgefeuert -> der Tag feuert nie.

Fix: das Script ohne `defer` laden, damit der Consent-Default synchron vor externen Tags im dataLayer steht. Das Script ist klein und same-origin, der render-blocking-Effekt ist vernachlaessigbar -- und fuer ein Consent-Script, das zwingend vor den Tags laufen muss, ist synchron im Head korrekt.