### PR TITLE
fix(external_thumbnail): Service-Erkennung auf unterstützte Dienste beschränken

### DIFF
--- a/lib/effect_external_thumbnail.php
+++ b/lib/effect_external_thumbnail.php
@@ -34,7 +34,15 @@ class rex_effect_external_thumbnail extends rex_effect_abstract
             $filename = $this->media->getMediaFilename();
 
             // Parameter aus Dateiname parsen: service_videoid_hash.jpg
-            if ((bool) preg_match('/^([^_]+)_([^_]+)_([^\.]+)\.jpg$/', $filename, $matches)) {
+            // Nur die tatsächlich unterstützten Services matchen, sonst wird jede
+            // beliebige Datei mit Unterstrichen im Namen als Video-Thumbnail
+            // interpretiert.
+            $servicePattern = implode('|', array_map(
+                static fn (string $knownService): string => preg_quote($knownService, '/'),
+                array_keys(self::SERVICES),
+            ));
+
+            if ((bool) preg_match('/^(' . $servicePattern . ')_([^_]+)_([^.]+)\.jpg$/', $filename, $matches)) {
                 $service = $matches[1];
                 $videoId = $matches[2];
             } else {
@@ -48,8 +56,11 @@ class rex_effect_external_thumbnail extends rex_effect_abstract
                 }
             }
 
+            // Kann nur noch über die Effect-Parameter auftreten; der Dateiname
+            // liefert per Konstruktion einen bekannten Service.
             if (!isset(self::SERVICES[$service])) {
-                throw new rex_exception('External thumbnail effect: Unsupported service "' . $service . '"');
+                $this->createFallbackImage();
+                return;
             }
 
             $thumbnailUrl = $this->getThumbnailUrl($service, $videoId);


### PR DESCRIPTION
### Problem

`lib/effect_external_thumbnail.php:37` ermittelt den Video-Service aus dem Dateinamen, trifft dabei aber jede `.jpg`-Datei mit mindestens zwei Unterstrichen im Namen – nicht nur die virtuellen Namen im Schema `service_videoid_hash.jpg`. Der erste Namensteil wird als Service interpretiert, Zeile 52 wirft dann `rex_exception: External thumbnail effect: Unsupported service "..."`.

Relevant wird das im Zusammenspiel mit `cache_warmup`: `install.php:182-216` legt den Medientyp `consent_manager_thumbnail` mit diesem Effect an, und cache_warmup rendert jedes Bild durch jeden Typ aus `rex_media_manager_type`. Pro betroffenem Bild entsteht dadurch ein Log-Eintrag und über den `catch` (Zeile 111-115) ein graues 480×360-Platzhalterbild, das der Media Manager anschließend als reguläre Cache-Datei ablegt.

Trifft ein Dateiname zufällig auf `youtube_` oder `vimeo_`, wird statt der Exception ein echter HTTP-Request an den externen Dienst abgesetzt – ebenfalls einmal pro Bild.

### Änderung

- Das Regex matcht nur noch die Keys aus `self::SERVICES`. Das Muster wird dynamisch aufgebaut, damit ein künftig ergänzter Dienst automatisch mitgezogen wird und die Konstante die einzige Quelle der Wahrheit bleibt.
- Der `throw` bei unbekanntem Service entfällt zugunsten des Fallback-Bilds. Das ist konsistent mit dem Verhalten bei fehlenden Parametern (Zeile 45-48), wo bereits still auf `createFallbackImage()` gegangen wird; der `catch` landete ohnehin beim selben Fallback, der Log-Eintrag hatte also keinen diagnostischen Wert.
- Die `isset`-Prüfung bleibt erhalten: sie sichert weiterhin den Parameter-Pfad (`$this->params['service']`) ab, wo weiterhin ein beliebiger Wert ankommen kann.

### Verhalten vorher / nachher

| Dateiname | vorher | nachher |
| --- | --- | --- |
| `youtube_<id>_<hash>.jpg` | match | match |
| `vimeo_<id>_<hash>.jpg` | match | match |
| `foo_bar_baz.jpg` | match → Service `foo` → Exception | kein Match |
| `foo_bar_baz_qux.jpg` | match → Service `foo` → Exception | kein Match |
| `youtubex_bar_baz.jpg` | match → Service `youtubex` → Exception | kein Match |
| `my_youtube_clip.jpg` | match → Service `my` → Exception | kein Match |

Die beiden echten Anwendungsfälle verhalten sich unverändert, alle anderen Namen fallen still durch.

### Workaround für Betroffene bis zum Release

```php
rex_extension::register('CACHE_WARMUP_MEDIATYPES', function (rex_extension_point $ep) {
    return array_values(array_diff($ep->getSubject(), ['consent_manager_thumbnail']));
});
```

### Umgebung

Gefunden mit consent_manager 5.8.3, cache_warmup 4.0.0, media_manager 2.18.3, REDAXO 5.21.4.

Den CHANGELOG habe ich bewusst nicht angefasst, da die Versionsnummer des nächsten Releases bei euch liegt – sagt gern Bescheid, dann ergänze ich einen Eintrag.
