### PR TITLE
Fix: Doppeltes HTML-Escaping im InlineConsent-Platzhalter

### DIFF
--- a/lib/InlineConsent.php
+++ b/lib/InlineConsent.php
@@ -291,13 +291,17 @@ class InlineConsent
         $debug = rex::isDebugMode();
 
         // Fragment verwenden für bessere Anpassbarkeit
+        // escape=false: Das Fragment escaped jedes Feld schon selbst gezielt (rex_escape) -
+        // Default-Escaping hier fuehrte zu doppelt escaptem Output (z.B. '&' -> '&amp;amp;').
+        // 'content' bleibt bewusst escaped: consent_inline.js liest es aus einem
+        // <script type="text/plain"> und dekodiert per textarea-Trick genau EINE Escape-Stufe.
         $fragment = new rex_fragment();
-        $fragment->setVar('serviceKey', $serviceKey);
+        $fragment->setVar('serviceKey', $serviceKey, false);
         $fragment->setVar('content', $content);
-        $fragment->setVar('options', $options);
-        $fragment->setVar('consentId', $consentId);
-        $fragment->setVar('service', $service);
-        $fragment->setVar('placeholderData', $placeholderData);
+        $fragment->setVar('options', $options, false);
+        $fragment->setVar('consentId', $consentId, false);
+        $fragment->setVar('service', $service, false);
+        $fragment->setVar('placeholderData', $placeholderData, false);
 
         if ($debug) {
             echo "<!-- DEBUG renderPlaceholderHTML: serviceKey=$serviceKey -->\n";
@@ -306,15 +310,15 @@ class InlineConsent
 
         // Alle Button-Texte für Fragment hinzufügen
         // TODO: Button-Texte etc. über .lang bereitstellen
-        $fragment->setVar('button_inline_details_text', self::getButtonText('button_inline_details', 'Einstellungen'));
-        $fragment->setVar('inline_placeholder_text', self::getButtonText('inline_placeholder_text', 'Einmal laden'));
-        $fragment->setVar('button_inline_allow_all_text', self::getButtonText('button_inline_allow_all', 'Alle erlauben'));
-        $fragment->setVar('inline_action_text', self::getButtonText('inline_action_text', 'Was möchten Sie tun?'));
+        $fragment->setVar('button_inline_details_text', self::getButtonText('button_inline_details', 'Einstellungen'), false);
+        $fragment->setVar('inline_placeholder_text', self::getButtonText('inline_placeholder_text', 'Einmal laden'), false);
+        $fragment->setVar('button_inline_allow_all_text', self::getButtonText('button_inline_allow_all', 'Alle erlauben'), false);
+        $fragment->setVar('inline_action_text', self::getButtonText('inline_action_text', 'Was möchten Sie tun?'), false);
         $fragment->setVar('show_allow_all', $options['show_allow_all'] ?? false);
         $privacyNotice = self::getButtonText('inline_privacy_notice', 'Für die Anzeige werden Cookies benötigt.');
-        $fragment->setVar('inline_privacy_notice', $privacyNotice);
-        $fragment->setVar('inline_title_fallback', self::getButtonText('inline_title_fallback', 'Externes Medium'));
-        $fragment->setVar('inline_privacy_link_text', self::getButtonText('inline_privacy_link_text', 'Datenschutzerklärung von'));
+        $fragment->setVar('inline_privacy_notice', $privacyNotice, false);
+        $fragment->setVar('inline_title_fallback', self::getButtonText('inline_title_fallback', 'Externes Medium'), false);
+        $fragment->setVar('inline_privacy_link_text', self::getButtonText('inline_privacy_link_text', 'Datenschutzerklärung von'), false);
 
         if ($debug) {
             // TODO: Texte über .lang aufbauen?
@@ -323,7 +327,7 @@ class InlineConsent
         }
 
         // Icon-Konfiguration
-        $fragment->setVar('privacy_icon', $options['privacy_icon'] ?? 'uk-icon:shield');
+        $fragment->setVar('privacy_icon', $options['privacy_icon'] ?? 'uk-icon:shield', false);
 
         return $fragment->parse('ConsentManager/inline_placeholder.php');
     }


### PR DESCRIPTION
## Bug

`InlineConsent::renderPlaceholderHTML()` übergibt `$options`, `$service`, `$placeholderData` sowie mehrere Button-Texte per `rex_fragment->setVar(...)` an das Fragment `fragments/ConsentManager/inline_placeholder.php` — ohne das automatische Escaping von `setVar()` (Default `$escape = true`) zu deaktivieren. Das Fragment escaped jedes dieser Felder aber zusätzlich selbst gezielt per `rex_escape()`, bevor es ausgegeben wird.

Enthält ein Wert Sonderzeichen (`&`, `<`, `>`, `"`, `'`), wird er dadurch doppelt escaped ausgegeben, z. B.:

```php
echo InlineConsent::doConsent('youtube', 'VIDEO_ID', [
    'title' => 'Erkrankung & Behandlungsmethoden',
]);
```

→ `alt="Erkrankung &amp;amp; Behandlungsmethoden"` statt `alt="Erkrankung &amp; Behandlungsmethoden"`.

Betrifft Titel, Alt-Text, Thumbnail-URLs, Privacy-Links und Button-Labels des Inline-Placeholders — überall dort, wo der Aufrufer selbst schon rohen Text übergibt (z. B. einen REDAXO-Modul-Wert) und das Fragment ihn erwartungsgemäß selbst escaped.

## Fix

`escape = false` bei allen `setVar()`-Aufrufen in `renderPlaceholderHTML()`, deren Wert das Fragment ohnehin selbst escaped.

Bewusste Ausnahme: `content` bleibt beim Default (`escape = true`). `consent_inline.js` liest diesen Wert aus einem `<script type="text/plain">`-Block und dekodiert ihn per Textarea-Trick um genau eine Escape-Stufe zurück (`loadContent()`) — das ist die bestehende, korrekte Funktionsweise und bleibt unangetastet.

## Reproduktion / Test

Lokal reproduziert und den Fix verifiziert beim Einbau von `doConsent()` für ein YouTube-Video mit `&` im Titel auf einer Kunden-Website (REDAXO 5.21.4, PHP 8.3, Docker). Vorher/nachher per curl gegen das gerenderte Frontend-HTML geprüft:

- Platzhalter-Titel (`<p class="consent-inline-title h4">`) und Thumbnail-`alt`: vorher `&amp;amp;`, nachher korrekt `&amp;`.
- `content`-Script (`<script type="text/plain" class="consent-content-data">`) unverändert weiterhin einfach escaped, wie von `consent_inline.js` erwartet.
- `php -l` sauber.

🤖 Erstellt mit Unterstützung von [Claude Code](https://claude.com/claude-code)